### PR TITLE
feat(perspective-agents): extend ownership tables to agent-rubric namespace

### DIFF
--- a/agents/review-perspective-clarity.md
+++ b/agents/review-perspective-clarity.md
@@ -3,7 +3,7 @@ name: review-perspective-clarity
 description: >
   Verifies step ordering, conditional specificity (WS-*), RD-5 dependency
   declarations, and PD-1 knowledge-placement in a Claude Code skill/agent/rule.
-  Use ONLY when dispatched by /review-skill with
+  Use ONLY when dispatched by /review-skill or /review-agent with
   subagent_type=review-perspective-clarity. Do NOT evaluate factual
   correctness (delegate to review-perspective-correctness) or cross-primitive
   integration (delegate to review-perspective-integration).
@@ -18,13 +18,13 @@ permissionMode: default
 
 # Review Perspective — Clarity
 
-If invoked outside a `/review-skill` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a review-skill dispatch target. Invoke /review-skill <path> instead." and stop.
+If invoked outside a `/review-skill` or `/review-agent` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a dispatch target for /review-skill or /review-agent. Invoke one of those commands with the artifact path instead." and stop.
 
 You verify step ordering, conditional specificity, step-dependency declarations, and knowledge placement in a Claude Code skill, agent, or rule. You produce a perspective certificate that the `/review-skill` orchestrator merges with two sibling perspectives.
 
 ## Ownership
 
-Primary focus items: WS-1, WS-2, WS-3, WS-4, RD-5, PD-1, PD-2, PD-3.
+Primary focus items: WS-1, WS-2, WS-3, WS-4, RD-5, PD-1, PD-2, PD-3, SF-2.
 Primary dimensions (weight 2× in orchestrator merge): Clarity.
 
 Binary items (CLAR-1..4) are evaluated deterministically by `scripts/rubric_binary_evaluator.py` before your dispatch; do NOT emit findings for them. See Workflow step 3.
@@ -33,8 +33,8 @@ Binary items (CLAR-1..4) are evaluated deterministically by `scripts/rubric_bina
 
 1. Read the shared prefix (scoring rubric + engineering baseline + source-quality criteria) and the per-type evaluation guide + boundary exemplars passed in your prompt.
 2. Read the artifact under review (labeled `## Item Under Review`).
-3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (26 items: META-1a/2/3a/3b/4, CLAR-1..4, CE-X, COMP-X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
-4. For each remaining primary focus item (WS-1/2/3/4, RD-5, PD-1/2/3): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity findings.
+3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (32 items: META-1a/2/3a/3b/3c/4, CLAR-1..4, WS-2b/5b/6, RD-5b, CE-X, COMP-V/X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
+4. For each remaining primary focus item (WS-1/2/3/4, RD-5, PD-1/2/3 on skill artifacts; SF-2 additionally on agent artifacts): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity findings.
 5. For every other non-skipped checklist item: emit PASS/FAIL briefly. Non-primary FAILs carry `primary_focus: false` and `owner_conflict: true` with `hint_owner` set to the responsible sibling perspective (correctness or integration).
 6. Score all 7 dimensions A–F per the rubric. Assume binary items PASS for grading purposes — the merge layer applies deterministic boundary caps on top of your grades. For primary dimensions (Clarity), evidence must cite ≥1 non-binary primary-focus item result.
 7. Emit certificate.
@@ -50,7 +50,7 @@ clarity
 ### Certificate
 | Dimension | Grade | Justification |
 |-----------|-------|---------------|
-| Clarity | [A-F] | [cite ≥1 WS-* or RD-5 item] |
+| Clarity | [A-F] | [cite ≥1 WS-*, RD-5, or SF-2 item] |
 | Completeness | [A-F] | [brief] |
 | Prompt Engineering | [A-F] | [brief] |
 | Context Engineering | [A-F] | [brief] |

--- a/agents/review-perspective-correctness.md
+++ b/agents/review-perspective-correctness.md
@@ -3,7 +3,7 @@ name: review-perspective-correctness
 description: >
   Verifies factual accuracy against scoring rubric COMP-X/Y/Z, CE-X,
   SAMP-1/2, and robustness checks RD-4, RD-6 in a Claude Code
-  skill/agent/rule. Use ONLY when dispatched by /review-skill with
+  skill/agent/rule. Use ONLY when dispatched by /review-skill or /review-agent with
   subagent_type=review-perspective-correctness. Do NOT evaluate step
   readability (delegate to review-perspective-clarity) or injection /
   tool-grant safety (delegate to review-perspective-integration).
@@ -18,13 +18,13 @@ permissionMode: default
 
 # Review Perspective — Correctness
 
-If invoked outside a `/review-skill` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a review-skill dispatch target. Invoke /review-skill <path> instead." and stop.
+If invoked outside a `/review-skill` or `/review-agent` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a dispatch target for /review-skill or /review-agent. Invoke one of those commands with the artifact path instead." and stop.
 
 You verify factual accuracy against the scoring rubric, completeness gates, sampling-parameter migration (SAMP-1/2), and error-handling robustness in a Claude Code skill, agent, or rule.
 
 ## Ownership
 
-Primary focus items: RD-4, RD-6, OF-1, OF-2, OF-3, OF-4, AH-1, AH-3, AP-3, AP-4, RF-1, RF-2, RF-3, AP-1.
+Primary focus items: RD-4, RD-6, OF-1, OF-2, OF-3, OF-4, AH-1, AH-3, AP-3, AP-4, RF-1, RF-2, RF-3, AP-1, TC-1, TC-2, TC-3, DA-4, DA-2a, DA-2b.
 Primary dimensions (weight 2× in orchestrator merge): Completeness, Prompt Engineering, Context Engineering, Goal Alignment.
 
 Binary items (COMP-X/Y/Z/W, CE-X, SAMP-1/2, PE-1/2, AH-2b) and narrative parents (AH-2) are evaluated deterministically by `scripts/rubric_binary_evaluator.py` before your dispatch; do NOT emit findings for them. See Workflow step 3.
@@ -33,8 +33,8 @@ Binary items (COMP-X/Y/Z/W, CE-X, SAMP-1/2, PE-1/2, AH-2b) and narrative parents
 
 1. Read the shared prefix (scoring rubric + engineering baseline + source-quality criteria) and the per-type evaluation guide + boundary exemplars passed in your prompt.
 2. Read the artifact under review (labeled `## Item Under Review`).
-3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (26 items: META-1a/2/3a/3b/4, CLAR-1..4, CE-X, COMP-X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
-4. For each remaining primary focus item (RD-4, RD-6, OF-1/2/3/4, AH-1/3, AP-1/3/4, RF-1/2/3): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity.
+3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (32 items: META-1a/2/3a/3b/3c/4, CLAR-1..4, WS-2b/5b/6, RD-5b, CE-X, COMP-V/X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
+4. For each remaining primary focus item (RD-4, RD-6, OF-1/2/3/4, AH-1/3, AP-1/3/4, RF-1/2/3 on skill artifacts; TC-1/2/3, DA-4, DA-2a, DA-2b additionally on agent artifacts): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity.
 5. For every other non-skipped checklist item: emit PASS/FAIL briefly. Non-primary FAILs carry `primary_focus: false` and `owner_conflict: true` with `hint_owner` set to the responsible sibling perspective (clarity or integration).
 6. Score all 7 dimensions A–F per the rubric. Assume binary items PASS for grading purposes — the merge layer applies deterministic boundary caps on top of your grades. For primary dimensions, evidence must cite ≥1 non-binary primary-focus item result.
 7. Emit certificate in the same output contract as the clarity perspective (see `### Perspective` / `### Certificate` / `### Findings` schema in the shared per-perspective protocol block).

--- a/agents/review-perspective-integration.md
+++ b/agents/review-perspective-integration.md
@@ -4,7 +4,7 @@ description: >
   Verifies cross-primitive dependencies (RD-1/2/3, PD-5), injection surface
   (IJ-*), tool-grant safety (SP-*), reliability constraints (RL-*), and
   metadata-trigger quality (META-1a/1b/2/3a/3b) in a Claude Code
-  skill/agent/rule. Use ONLY when dispatched by /review-skill with
+  skill/agent/rule. Use ONLY when dispatched by /review-skill or /review-agent with
   subagent_type=review-perspective-integration. Do NOT evaluate step
   readability (delegate to review-perspective-clarity) or factual
   rubric-accuracy (delegate to review-perspective-correctness).
@@ -19,13 +19,13 @@ permissionMode: default
 
 # Review Perspective — Integration
 
-If invoked outside a `/review-skill` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a review-skill dispatch target. Invoke /review-skill <path> instead." and stop.
+If invoked outside a `/review-skill` or `/review-agent` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a dispatch target for /review-skill or /review-agent. Invoke one of those commands with the artifact path instead." and stop.
 
 You verify cross-primitive dependencies, injection surface, tool-grant safety, reliability constraints, and metadata-trigger quality in a Claude Code skill, agent, or rule.
 
 ## Ownership
 
-Primary focus items: RD-1, RD-2, RD-3, PD-5, SP-1, SP-3, RT-1, RT-2, RT-3, META-1b, AH-4, AP-2, WS-4.
+Primary focus items: RD-1, RD-2, RD-3, PD-5, SP-1, SP-3, RT-1, RT-2, RT-3, META-1b, AH-4, AP-2, WS-4, TV-1, TV-2, TV-3, TV-4, TV-5, TV-6, AF-1, AF-2, AF-3, AF-4, AF-5, AF-6, AF-7, GV-1, GV-2, IJ-2, MS-1.
 Primary dimensions (weight 2× in orchestrator merge): Safety, Metadata.
 
 Binary items (META-1a/2/3a/3b/4, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b) and narrative parents (SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3) are evaluated deterministically by `scripts/rubric_binary_evaluator.py` before your dispatch; do NOT emit findings for them. See Workflow step 3.
@@ -34,8 +34,8 @@ Binary items (META-1a/2/3a/3b/4, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b) and narrative 
 
 1. Read the shared prefix (scoring rubric + engineering baseline + source-quality criteria) and the per-type evaluation guide + boundary exemplars passed in your prompt.
 2. Read the artifact under review (labeled `## Item Under Review`).
-3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (26 items: META-1a/2/3a/3b/4, CLAR-1..4, CE-X, COMP-X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
-4. For each remaining primary focus item (RD-1/2/3, PD-5, SP-1, SP-3, RT-1/2/3, META-1b, AH-4, AP-2, WS-4): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity.
+3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (32 items: META-1a/2/3a/3b/3c/4, CLAR-1..4, WS-2b/5b/6, RD-5b, CE-X, COMP-V/X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
+4. For each remaining primary focus item (RD-1/2/3, PD-5, SP-1, SP-3, RT-1/2/3, META-1b, AH-4, AP-2, WS-4 on skill artifacts; TV-1, TV-2, TV-3, TV-4, TV-5, TV-6, AF-1, AF-2, AF-3, AF-4, AF-5, AF-6, AF-7, GV-1, GV-2, IJ-2, MS-1 additionally on agent artifacts): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity.
    - **Verify-before-fail (cross-primitive existence).** Before emitting any FAIL whose evidence asserts that a referenced primitive (agent, skill, hook, script, MCP server) does not exist, verify with Glob or Read in this fixed order: (1) flat form first — `agents/<name>.md` (or `skills/<name>.md`, `hooks/<name>.py`, `scripts/<name>.py`); (2) recursive form `**/agents/<name>.md` for vendored plugins; (3) nested form `agents/<name>/AGENT.md` (rare layout). Stop at the first match and treat it as proof of existence. For plugin-namespaced subagent values (`<plugin>:<name>`), strip the prefix before Globbing. Emit FAIL only when ALL three candidate Globs return zero matches. If Glob errors, downgrade severity to Medium and prefix `evidence:` with the literal token `VERIFICATION-FAILED:` followed by the failure mode — never assert non-existence without a completed Glob round-trip on the flat form. Defense in depth: `scripts/merge_findings.py` deterministically post-filters missing-primitive findings against the actual repo state, but that backstop should not substitute for an honest in-agent verification. RD-1 stays scoped to *trigger-phrase specificity* (Metadata); cross-primitive existence is part of this agent's own frontmatter mandate (line 4) and surfaces under the matching specific item (e.g., AP-2 for tools listed in `allowed-tools`), not RD-1.
 5. For every other non-skipped checklist item: emit PASS/FAIL briefly. Non-primary FAILs carry `primary_focus: false` and `owner_conflict: true` with `hint_owner` set to the responsible sibling perspective (clarity or correctness).
 6. Score all 7 dimensions A–F per the rubric. Assume binary items PASS for grading purposes — the merge layer applies deterministic boundary caps on top of your grades. For primary dimensions, evidence must cite ≥1 non-binary primary-focus item result.

--- a/tests/fixtures/rubric_evaluator/agents/review-perspective-clarity.md
+++ b/tests/fixtures/rubric_evaluator/agents/review-perspective-clarity.md
@@ -3,7 +3,7 @@ name: review-perspective-clarity
 description: >
   Verifies step ordering, conditional specificity (WS-*), RD-5 dependency
   declarations, and PD-1 knowledge-placement in a Claude Code skill/agent/rule.
-  Use ONLY when dispatched by /review-skill with
+  Use ONLY when dispatched by /review-skill or /review-agent with
   subagent_type=review-perspective-clarity. Do NOT evaluate factual
   correctness (delegate to review-perspective-correctness) or cross-primitive
   integration (delegate to review-perspective-integration).
@@ -18,13 +18,13 @@ permissionMode: default
 
 # Review Perspective — Clarity
 
-If invoked outside a `/review-skill` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a review-skill dispatch target. Invoke /review-skill <path> instead." and stop.
+If invoked outside a `/review-skill` or `/review-agent` dispatch context (no `---orchestration---` metadata block in the prompt), respond with: "This agent is a dispatch target for /review-skill or /review-agent. Invoke one of those commands with the artifact path instead." and stop.
 
 You verify step ordering, conditional specificity, step-dependency declarations, and knowledge placement in a Claude Code skill, agent, or rule. You produce a perspective certificate that the `/review-skill` orchestrator merges with two sibling perspectives.
 
 ## Ownership
 
-Primary focus items: WS-1, WS-2, WS-3, WS-4, RD-5, PD-1, PD-2, PD-3.
+Primary focus items: WS-1, WS-2, WS-3, WS-4, RD-5, PD-1, PD-2, PD-3, SF-2.
 Primary dimensions (weight 2× in orchestrator merge): Clarity.
 
 Binary items (CLAR-1..4) are evaluated deterministically by `scripts/rubric_binary_evaluator.py` before your dispatch; do NOT emit findings for them. See Workflow step 3.
@@ -33,8 +33,8 @@ Binary items (CLAR-1..4) are evaluated deterministically by `scripts/rubric_bina
 
 1. Read the shared prefix (scoring rubric + engineering baseline + source-quality criteria) and the per-type evaluation guide + boundary exemplars passed in your prompt.
 2. Read the artifact under review (labeled `## Item Under Review`).
-3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (26 items: META-1a/2/3a/3b/4, CLAR-1..4, CE-X, COMP-X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
-4. For each remaining primary focus item (WS-1/2/3/4, RD-5, PD-1/2/3): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity findings.
+3. Skip emitting findings for any checklist item marked binary in `scoring-rubric.md` §"Binary-Verifiable Rubric Items" (32 items: META-1a/2/3a/3b/3c/4, CLAR-1..4, WS-2b/5b/6, RD-5b, CE-X, COMP-V/X/Y/Z/W, SAMP-1/2, PE-1/2, SP-2b/4b, IJ-1b, RL-1b/3b/4b/9b, AH-2b). Also skip the narrative parent items the rubric supersedes: AH-2, SP-2, SP-4, IJ-1, RL-1, RL-3, RL-4, RL-9, META-1, META-2, META-3. These are evaluated deterministically by the merge layer; your emissions for them are dropped.
+4. For each remaining primary focus item (WS-1/2/3/4, RD-5, PD-1/2/3 on skill artifacts; SF-2 additionally on agent artifacts): emit PASS/FAIL with evidence (quote from the artifact + path/line). Primary-focus FAILs are High-severity findings.
 5. For every other non-skipped checklist item: emit PASS/FAIL briefly. Non-primary FAILs carry `primary_focus: false` and `owner_conflict: true` with `hint_owner` set to the responsible sibling perspective (correctness or integration).
 6. Score all 7 dimensions A–F per the rubric. Assume binary items PASS for grading purposes — the merge layer applies deterministic boundary caps on top of your grades. For primary dimensions (Clarity), evidence must cite ≥1 non-binary primary-focus item result.
 7. Emit certificate.
@@ -50,7 +50,7 @@ clarity
 ### Certificate
 | Dimension | Grade | Justification |
 |-----------|-------|---------------|
-| Clarity | [A-F] | [cite ≥1 WS-* or RD-5 item] |
+| Clarity | [A-F] | [cite ≥1 WS-*, RD-5, or SF-2 item] |
 | Completeness | [A-F] | [brief] |
 | Prompt Engineering | [A-F] | [brief] |
 | Context Engineering | [A-F] | [brief] |


### PR DESCRIPTION
Closes #75.

## Summary

Extends Primary Focus tables in all 3 perspective agents (`agents/review-perspective-{clarity,correctness,integration}.md`) so PF coverage spans both skill and agent rubric namespaces. Prerequisite for `/review-agent` multi-perspective dispatch (#73).

## Changes

| File | Edit |
|---|---|
| `agents/review-perspective-clarity.md` | Add `SF-2` (Clarity-dim) to PF; loosen description + body guard to accept `/review-agent` dispatch; correct binary skip-list count `26 → 32` |
| `agents/review-perspective-correctness.md` | Add `TC-1, TC-2, TC-3, DA-4` (Compl-dim) + `DA-2a, DA-2b` (CE-dim) to PF; same loosening + count fix |
| `agents/review-perspective-integration.md` | Add `TV-1..6, AF-1..7, GV-1, GV-2, IJ-2, MS-1` (17 items) to PF; same loosening + count fix |
| `tests/fixtures/rubric_evaluator/agents/review-perspective-clarity.md` | Mirror byte-for-byte (live-copy fixture) |

## Deviation from issue body

3 items re-routed per `AGENT_ITEM_DIMENSION` authority (`scripts/merge_findings.py:171-213`):

| Item | Issue placement | Pin (source of truth) | Re-routed to | Reason |
|---|---|---|---|---|
| `DA-2a` | clarity | CE | correctness | CE is correctness's primary dim |
| `DA-2b` | clarity | CE | correctness | same |
| `MS-1` | correctness | Metadata | integration | Meta is integration's primary dim |

Issue body's annotations ("Meta-pinned but readability-adjacent" for DA-2a/2b; "model-match" for MS-1) appear to be authoring slips. Re-routing keeps the `AGENT_ITEM_DIMENSION` table as the single source of truth and avoids reproducing the dim-drift class #75 was filed to fix.

`AF-1..7` stay grouped in integration per the issue body's explicit "agent frontmatter validation" intent (`AF-4` annotated as cross-dim `Safety` ownership; the bundling is intentional, not a slip). Workflow step 5's `owner_conflict: true` mechanism handles cross-dim hand-off without re-routing.

## Validation

All 8 acceptance criteria (per issue `## Validation to close`) pass:

- AC-1: PF coverage on both rubric namespaces — ✅ (anchored grep on canonical PF line)
- AC-2: descriptions accept `/review-skill` and `/review-agent`, no stale form — ✅
- AC-3: body guards updated consistently — ✅
- AC-4: `IJ-1` not in any PF list (POSIX `\bIJ-1\b` excludes `IJ-1b`) — ✅
- AC-5: `AF-4` ownership = integration only — ✅
- AC-6: `diff -q` fixture vs live agent — ✅ exit 0
- AC-7: skill-side PF items preserved (additive-only edits) — ✅
- AC-8: `make validate` — ✅ green (lint, format, schema-validate, token-budget, 938 tests pass)

## Test plan

- [x] `make validate` green locally
- [x] Pinned fixture verdict map at `tests/test_rubric_binary_evaluator.py:1343-1376` unchanged (rubric_binary_evaluator.py not modified)
- [ ] CI green
- [ ] Manual smoke-check post-merge: re-run `/review-skill` on a skill artifact to confirm deterministic-subset finding-id parity (AC-7 manual canonical predicate, deferred to manual gate per plan)
