### PR TITLE
chore(housekeeping): cross-repo foundation — LICENSE, CONTRIBUTING, install.sh, README paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing
+
+Thanks for your interest in `review-claude-config`. This guide covers the
+contribution workflow. Maintainer-level operating policy (architecture,
+hard constraints, command inventory) lives in [CLAUDE.md](CLAUDE.md).
+
+## Prerequisites
+
+- **Python 3.11+** — required for hooks and validation scripts
+- **Claude Code CLI** — for testing skills/agents/hooks in dev mode
+- **`uv`** (recommended) or `pip` — Python dependency manager
+- **`make`** — drives the validation pipeline
+
+## Local Setup
+
+```bash
+git clone https://github.com/Nosmoht/review-claude-config.git
+cd review-claude-config
+
+# Create a venv and install dev dependencies
+python3 -m venv .venv
+.venv/bin/pip install -e ".[dev]"
+```
+
+The Makefile auto-detects `.venv/bin/python` and falls back to `python3`
+when no venv is present.
+
+## Running Validation
+
+A single command runs every gate:
+
+```bash
+make validate
+```
+
+This executes:
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| Lint | `make lint` | `ruff check hooks/ scripts/` |
+| Format | `make format` | `ruff format --check hooks/ scripts/` |
+| Schema | `make schema-validate` | Validates JSON schemas under `schemas/` |
+| Token budget | `make token-budget` | Enforces per-file token budgets |
+| Tests | `make test` | `pytest tests/ -v --tb=short` |
+
+`make validate` must pass before any commit lands on `main`.
+
+## Commit Format
+
+Conventional commits, scoped:
+
+```
+type(scope): short imperative description
+
+Optional body, wrapped at 72 chars. Self-contained — no tracker IDs
+(no NOS-, JIRA-, LIN-, GH issue links etc.) in the body.
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+
+Commit signing and pre-commit hooks must run — never bypass with
+`--no-verify` or `--no-gpg-sign`.
+
+## Pull Request Process
+
+1. Branch from latest `main`:
+   ```bash
+   git fetch origin && git pull origin main --ff-only
+   git checkout -b <type>/<short-slug>
+   ```
+2. Make changes and run `make validate`.
+3. For changes to skills, agents, rules, hooks, or CLAUDE.md, also run
+   the matching review skill (see CLAUDE.md §"Verify changes with the
+   repo's own review skills").
+4. Open a PR against `main`. Keep PRs small and scoped.
+5. Address review feedback; squash fixup commits into meaningful units
+   before merge.
+
+## Reporting Issues
+
+Search existing issues first:
+
+```bash
+gh issue list --repo Nosmoht/review-claude-config
+```
+
+When opening a new issue, populate the testable acceptance criteria
+(R1), defined deliverable (R2), single interpretation path (R3), and
+bounded scope (R4) sections — see CLAUDE.md §"Issue Lifecycle" for the
+canonical readiness predicates.
+
+## Maintainer Reference
+
+For architecture, hard constraints, label taxonomy, evidence layer,
+and the full command inventory, see [CLAUDE.md](CLAUDE.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ntbc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Evidence-based review plugin for Claude Code skills, agents, and rules.
 
 `review-claude-config` audits Claude Code primitives, produces review reports, helps apply findings, and provides maintenance utilities for the review system itself.
 
-Use this file as the user-facing entrypoint. Maintainer policy lives in [`CLAUDE.md`](/home/nos-ai/workspace/review-claude-config/CLAUDE.md). System documentation lives in [`docs/skills/README.md`](/home/nos-ai/workspace/review-claude-config/docs/skills/README.md).
+Use this file as the user-facing entrypoint. Maintainer policy lives in [`CLAUDE.md`](CLAUDE.md). System documentation lives in [`docs/skills/README.md`](docs/skills/README.md).
 
 ## Installation
 
@@ -109,7 +109,7 @@ cp -r .claude/skills/sync-research-index <target>/.claude/skills/
 
 ## Where To Look Next
 
-- [`CLAUDE.md`](/home/nos-ai/workspace/review-claude-config/CLAUDE.md) - maintainer operating guide and authoritative maintainer command inventory
-- [`docs/skills/README.md`](/home/nos-ai/workspace/review-claude-config/docs/skills/README.md) - skill and hook index, workflow chains, and system map
-- [`docs/evidence-maintenance.md`](/home/nos-ai/workspace/review-claude-config/docs/evidence-maintenance.md) - evidence maintenance policy
-- [`docs/scientific-research-dossier.md`](/home/nos-ai/workspace/review-claude-config/docs/scientific-research-dossier.md) - current evidence narrative and open questions
+- [`CLAUDE.md`](CLAUDE.md) - maintainer operating guide and authoritative maintainer command inventory
+- [`docs/skills/README.md`](docs/skills/README.md) - skill and hook index, workflow chains, and system map
+- [`docs/evidence-maintenance.md`](docs/evidence-maintenance.md) - evidence maintenance policy
+- [`docs/scientific-research-dossier.md`](docs/scientific-research-dossier.md) - current evidence narrative and open questions

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# install.sh — preflight check for review-claude-config plugin install.
+#
+# This script verifies host prerequisites and prints the canonical
+# install commands. It does NOT install the plugin automatically — the
+# `claude plugin install` flow is the supported entry point. Running
+# this script catches version mismatches before the plugin is fetched.
+
+set -euo pipefail
+
+PLUGIN_NAME="skill-quality"
+MARKETPLACE="ntbc-plugins"
+MARKETPLACE_REPO="Nosmoht/review-claude-config"
+MIN_PYTHON_MAJOR=3
+MIN_PYTHON_MINOR=11
+
+ok()   { printf '  \033[32mok\033[0m  %s\n' "$*"; }
+warn() { printf '  \033[33m!!\033[0m  %s\n' "$*"; }
+fail() { printf '  \033[31mxx\033[0m  %s\n' "$*"; exit 1; }
+info() { printf '  ..  %s\n' "$*"; }
+
+echo "review-claude-config preflight"
+echo "------------------------------"
+
+# Claude Code CLI
+if command -v claude >/dev/null 2>&1; then
+  CLAUDE_VERSION="$(claude --version 2>/dev/null || echo unknown)"
+  ok "claude CLI present (${CLAUDE_VERSION})"
+else
+  fail "claude CLI not found in PATH. Install from https://claude.com/claude-code first."
+fi
+
+# Python version
+if command -v python3 >/dev/null 2>&1; then
+  PY_VERSION="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+  PY_MAJOR="${PY_VERSION%.*}"
+  PY_MINOR="${PY_VERSION#*.}"
+  if [ "${PY_MAJOR}" -gt "${MIN_PYTHON_MAJOR}" ] || \
+     { [ "${PY_MAJOR}" -eq "${MIN_PYTHON_MAJOR}" ] && [ "${PY_MINOR}" -ge "${MIN_PYTHON_MINOR}" ]; }; then
+    ok "python3 ${PY_VERSION} (>= ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR})"
+  else
+    fail "python3 ${PY_VERSION} is too old; need >= ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}."
+  fi
+else
+  fail "python3 not found in PATH."
+fi
+
+# Hooks directory sanity check (only relevant when running from a clone)
+if [ -d "hooks" ] && [ -f "hooks/hooks.json" ]; then
+  ok "hooks/hooks.json present (running from repo clone)"
+else
+  info "hooks/hooks.json not seen here — running outside repo clone is fine"
+fi
+
+echo
+echo "Install via personal marketplace:"
+echo
+echo "  claude plugin marketplace add ${MARKETPLACE_REPO}"
+echo "  claude plugin install ${PLUGIN_NAME}@${MARKETPLACE}"
+echo
+echo "Dev mode (run from a repo clone, takes precedence over marketplace):"
+echo
+echo "  claude --plugin-dir ."
+echo
+echo "See README.md for update / rollback flows."


### PR DESCRIPTION
## Summary

Phase 0 of issue #36 housekeeping umbrella — covers C8/C9/C10/C11 in a single mechanical PR. C7 (versioning + CHANGELOG) is already satisfied by the v1.1.0 release.

- **C8 — LICENSE**: MIT, holder \`ntbc\`, year 2026.
- **C9 — README absolute paths**: replaced four \`/home/nos-ai/workspace/review-claude-config/...\` links with repo-relative paths (lines 9, 112–115). Verified clean via \`grep '/home/' README.md\`.
- **C10 — CONTRIBUTING.md**: prerequisites (Python 3.11+, uv/pip, claude CLI), \`make validate\` as the canonical gate, conventional commit format, PR process, cross-reference to CLAUDE.md for maintainer-level policy.
- **C11 — install.sh**: preflight script that checks for the \`claude\` CLI and Python ≥3.11, then prints the canonical marketplace install commands plus the \`--plugin-dir\` dev-mode flow. Does not auto-install — \`claude plugin install\` remains the supported entry point. \`chmod +x\` applied.

## Test plan

- [x] \`make validate\` (969 tests, 0 failures)
- [x] \`bash -n install.sh\` syntax check
- [x] \`./install.sh\` smoke-tested locally — preflight passes (claude 2.1.119, Python 3.14)
- [x] \`grep '/home/' README.md\` returns no results
- [x] Commit signed (verified via \`git log --show-signature\`)

Closes part of #36 (C8/C9/C10/C11). C7-residual (CHANGELOG.md) tracked separately as a v1.1.0 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)