### PR TITLE
fix(skills): add pre-Write guards to stop report Writes from tripping block-sensitive-content.sh

### DIFF
--- a/scripts/validate_token_budgets.py
+++ b/scripts/validate_token_budgets.py
@@ -114,6 +114,10 @@ BUDGETS: dict[str, int] = {
     "opus-4.7-migration-checks.md": 800,  # P0.1 extraction target
     "mcp-2026-security-checklist.md": 800,  # P0.3 extraction target
     "injection-regex-library.md": 1500,  # P0.3 — 22 Tier-A patterns + procedure
+    # Issue #145: schema files gained one above-field comment line
+    # instructing $HOME/ usage; legitimately over 500-token default.
+    "audit-report-schema.md": 600,
+    "context-report-schema.md": 600,
 }
 
 DOMAIN_CACHE_BUDGET = 800

--- a/skills/audit-context-budget/SKILL.md
+++ b/skills/audit-context-budget/SKILL.md
@@ -225,7 +225,7 @@ Resolve `<repo-slug>` per `repo-identification.md`. Include `repo: <slug>` and o
 
 ## Hard Rules
 
-- Read-only on the target repository. Write only the report file to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/`.
+- Read-only on the target repository. Write only the report file to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/`. Before Write, scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
 - Token estimates are always ranges (chars/4 to chars/3), always labeled "estimated".
 - Every recommendation cites the evidence tier and specific file paths measured.
 - Never recommend removing MCP servers, skills, or rules. Report cost only.

--- a/skills/audit-context-budget/references/context-report-schema.md
+++ b/skills/audit-context-budget/references/context-report-schema.md
@@ -13,7 +13,8 @@ schema_version: 2
 date: YYYY-MM-DD
 repo: <slug>                           # required — basename(target_dir), sanitized
 origin: <git-remote-url>               # optional — git remote URL when available
-target: /absolute/path
+# MUST use the literal token `$HOME/` (not the resolved absolute home prefix). block-sensitive-content.sh denies Write otherwise.
+target: $HOME/path/to/repo
 total_tokens_low: N
 total_tokens_high: N
 status: healthy|warning|critical

--- a/skills/audit-repo/SKILL.md
+++ b/skills/audit-repo/SKILL.md
@@ -390,6 +390,8 @@ Present the full report to the user.
 
 After presenting, confirm before writing: "Save audit report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-audit-repo.md`?"
 
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including evidence citations and action-plan command paths) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
+
 If confirmed, write the report. Create `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/` if it does not exist. If declined, display the path that would have been used.
 
 Suggest committing with: `docs(reviews): add YYYY-MM-DDTHHMMSS audit-repo report`

--- a/skills/audit-repo/references/audit-report-schema.md
+++ b/skills/audit-repo/references/audit-report-schema.md
@@ -15,7 +15,8 @@ schema_version: 2                      # v1=review, v2=audit
 date: YYYY-MM-DD
 repo: <slug>                           # basename(target_dir)
 origin: <git-remote-url>               # Optional
-target: /absolute/path
+# MUST use the literal token `$HOME/` (not the resolved absolute home prefix). block-sensitive-content.sh denies Write otherwise.
+target: $HOME/path/to/repo
 existing_claude_config: true|false
 languages: [python, typescript]
 repo_type: Application|Skills-Config|Mixed

--- a/skills/audit-repo/references/report-template.md
+++ b/skills/audit-repo/references/report-template.md
@@ -8,7 +8,7 @@ last_refreshed: 2026-04-06
 # Repository Audit Report
 
 ## Repository Profile
-- **Target:** [absolute path]
+- **Target:** $HOME/path/to/repo  (literal `$HOME/` token; never the resolved absolute home prefix — block-sensitive-content.sh denies Write)
 - **Languages:** [detected]
 - **Frameworks:** [detected]
 - **Existing Claude Config:** [yes/no — N skills, N agents, N rules, hooks: yes/no]

--- a/skills/review-agent/SKILL.md
+++ b/skills/review-agent/SKILL.md
@@ -166,6 +166,7 @@ In orchestrated mode, skip this phase entirely — return only the structured ce
 
 In standalone mode:
 1. Present the certificate to the user.
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-finding evidence quotations) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
 2. Confirm before writing: "Save review report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-agent.md`?"
 3. If confirmed, assemble the report using the canonical frontmatter contract located in Step 1 with:
    - `generated_by: review-agent`

--- a/skills/review-claude-config/SKILL.md
+++ b/skills/review-claude-config/SKILL.md
@@ -313,6 +313,8 @@ For every High or Medium recommendation in the body, preserve the shared recomme
 
 ### Step 2: Write the report
 
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-item recommendation evidence) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
+
 Write to: `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-claude-config.md`
 
 Use the current date and time for the timestamp. Create the `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/` directory if it does not exist. Timestamp ensures each run produces a unique file, supporting the "iterate until convergence" workflow.

--- a/skills/review-claude-config/references/review-report-contract.md
+++ b/skills/review-claude-config/references/review-report-contract.md
@@ -42,7 +42,8 @@ schema_version: 1
 date: YYYY-MM-DD
 repo: <slug>                # basename(target_dir)
 origin: <git-remote-url>    # Optional
-target: /absolute/path
+# MUST use the literal token `$HOME/` (not the resolved absolute home prefix). block-sensitive-content.sh denies Write otherwise. Applies to review-skill, review-agent, review-rule, review-claude-md, review-mcp-server.
+target: $HOME/path/to/repo
 baseline_version: YYYY-MM-DD
 items_reviewed: N
 summary:

--- a/skills/review-claude-md/SKILL.md
+++ b/skills/review-claude-md/SKILL.md
@@ -188,6 +188,7 @@ In orchestrated mode, skip this phase entirely — return only the structured ce
 
 In standalone mode:
 1. Present the certificate to the user.
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-finding evidence quotations) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
 2. Confirm before writing: "Save review report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-claude-md.md`?"
 3. If confirmed, assemble the report using the canonical frontmatter contract located in Step 1 with:
    - `generated_by: review-claude-md`

--- a/skills/review-mcp-server/SKILL.md
+++ b/skills/review-mcp-server/SKILL.md
@@ -104,6 +104,7 @@ Produce the certificate:
 
 ## Phase 3 — Report (standalone mode only)
 
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-finding evidence quotations) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
 1. Write the review report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-mcp-server.md` with frontmatter matching the review report contract. Include `repo: <slug>` and optionally `origin: <git-remote-url>` in the frontmatter (after `date`). Create the `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/` directory if it does not exist.
 2. Suggest commit message: `docs(reviews): add YYYY-MM-DDTHHMMSS MCP server review report`.
 

--- a/skills/review-rule/SKILL.md
+++ b/skills/review-rule/SKILL.md
@@ -152,6 +152,7 @@ In orchestrated mode, skip this phase entirely — return only the structured ce
 
 In standalone mode:
 1. Present the certificate to the user.
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-finding evidence quotations) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
 2. Confirm before writing: "Save review report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-rule.md`?"
 3. If confirmed, assemble the report using the canonical frontmatter contract located in Step 1 with:
    - `generated_by: review-rule`

--- a/skills/review-skill/SKILL.md
+++ b/skills/review-skill/SKILL.md
@@ -330,6 +330,7 @@ In orchestrated mode, skip this phase entirely — return only the structured ce
 
 In standalone mode:
 1. Present the certificate to the user.
+Before Write: scan the assembled report (frontmatter `target:`, optional `origin:`, and the entire body including per-finding evidence quotations) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes. Also applies to the findings.json sidecar (Phase 4 step 5).
 2. Confirm before writing: "Save review report to `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-review-skill.md`?"
 3. If confirmed, assemble the report using the canonical frontmatter contract located in Step 1 with:
    - `generated_by: review-skill`

--- a/skills/suggest-skills/SKILL.md
+++ b/skills/suggest-skills/SKILL.md
@@ -404,6 +404,8 @@ If the user declines, skip report writing but still display the report path that
 
 **Body:** Full report content as presented.
 
+Before Write: scan the assembled report (frontmatter `target:` and the entire body) and replace any literal absolute home-directory prefix with `$HOME/`. The `~/.claude/hooks/block-sensitive-content.sh` PreToolUse hook denies Writes containing such prefixes.
+
 Write to: `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/YYYY-MM-DDTHHMMSS-suggest-skills.md`
 
 Use the current date and time for the timestamp. Create `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/` if it does not exist.

--- a/skills/suggest-skills/references/report-template.md
+++ b/skills/suggest-skills/references/report-template.md
@@ -11,7 +11,7 @@ last_refreshed: 2026-04-06
 
 ## Repository Overview
 
-- **Target:** [absolute path]
+- **Target:** $HOME/path/to/repo  (literal `$HOME/` token; never the resolved absolute home prefix — block-sensitive-content.sh denies Write)
 - **Repository Type:** [Application / Skills-Config / Mixed]
 - **Tech Stack:** [detected languages, frameworks, infrastructure — or "N/A (skills/config repository)" if no source code]
 - **Existing Skills:** [count] ([list names])
@@ -64,7 +64,8 @@ last_refreshed: 2026-04-06
 generated_by: suggest-skills
 schema_version: 1
 date: YYYY-MM-DD
-target: /absolute/path/to/target
+# MUST use the literal token `$HOME/` (not the resolved absolute home prefix). block-sensitive-content.sh denies Write otherwise.
+target: $HOME/path/to/repo
 repo_type: Application | Skills-Config | Mixed
 existing_skills: N
 suggestions:


### PR DESCRIPTION
## Summary

Closes #145.

The user-global PreToolUse hook `~/.claude/hooks/block-sensitive-content.sh` blocks any Write whose body contains the literal absolute home-directory prefix in doc-targets. Audit/review skills currently emit reports with `target:` frontmatter populated by the analyzed repo's resolved absolute path — the hook denies the Write and Phase 5 aborts mid-flight (Probe-1, 2026-05-02; blocked Cross-Repo-GA).

This PR fixes 8 report-emitting skills (audit-repo, audit-context-budget, suggest-skills, and the five review-* skills) and the batch orchestrator (review-claude-config) by:

- Replacing schema/template `target: /absolute/path` placeholders with `target: $HOME/path/to/repo` plus a one-line comment ABOVE the field directing the LLM to use the literal `$HOME/` token.
- Inserting a per-skill pre-Write guard at all 9 SKILL.md persistence sites that scans the assembled report (`target:`, optional `origin:`, the entire body including evidence citations and action-plan command paths) and rewrites any literal absolute home-directory prefix to `$HOME/` before the Write.

Out of scope (per Issue #145 R4): the hook itself; analyzed-repo files; relative paths; non-self / cross-user home-prefix denial. The cross-user case is filed as follow-up #156 because it needs `<analyzed-user>` placeholder semantics rather than `$HOME/` (anonymization vs portability — different concern).

Plan revision history v1 → v2 → v3 surfaced and resolved one CRITICAL plan-review finding (5 review-* skills have their own Write step; the batch orchestrator does not cover them) and three HIGH findings (R1 testability via `.work/issue-145/evaluator-cmds.sh` dry-run; cross-user scope clarification; R3b grep tightened from "any mention of hook" to specific guard phrasing).

## Test plan

- [x] `make validate` — green (975 tests)
- [x] R1a: schema/template placeholders show `$HOME/path/to/repo` (4 + 2 grep matches)
- [x] R1b: `bash .work/issue-145/evaluator-cmds.sh` — hook accepts `$HOME` form, rejects literal-home form (exit 0)
- [x] R3a: no `/absolute/path` placeholder remains in scope (exit 0)
- [x] R3b: pre-Write guard phrase present in all 9 SKILL.md files (9 file paths)
- [x] R4a: `hooks/block-sensitive-content.sh` not modified
- [x] R4b: only in-scope files modified (plus prerequisite `scripts/validate_token_budgets.py` budget bump for two schemas that exceeded the 500-token default after adding the comment lines)
- [ ] Manual e2e: fresh-session `/audit-repo .` Phase-5 Write completes without `BLOCKED:` stderr (deferred to post-merge in user environment)