### PR TITLE
feat(skills): add Agent and Rule signal tables to signal-catalog

### DIFF
--- a/scripts/validate_token_budgets.py
+++ b/scripts/validate_token_budgets.py
@@ -48,7 +48,7 @@ BUDGETS: dict[str, int] = {
     # 2026 incl. CVSS 9.6 RCE).
     "tool-grant-decision-tree.md": 800,
     "engineering-baseline.md": 4350,  # +#92 GA + #93 linguistic-failure + #97 CoVe + #46 Dynamic Tool Loadout upgrade
-    "signal-catalog.md": 1000,
+    "signal-catalog.md": 1400,
     # Evaluation guides — dense checklists, legitimately >500.
     # Opus 4.7 tokenizer ~35% larger than 4.6 — bumped per plan rev4.
     # Issue #69: +CLAR-3/4, SP-2b/4b, RL-1b/3b/4b/9b, IJ-1b rows

--- a/skills/audit-repo/SKILL.md
+++ b/skills/audit-repo/SKILL.md
@@ -296,11 +296,25 @@ In the intervention matrix, include a `signal_source` for each Skill row: "repet
 
 ### 4C: Agent Candidates
 
+#### Signal catalog checks
+
+Using the signal-catalog.md loaded in Phase 1, match Phase 2 scan results
+against the Agent Candidate Signal Table.
+
+For each signal row in the table:
+1. Check if the Detection Pattern matches Phase 2 findings
+2. Check if a corresponding agent already exists (from Phase 1 Step 2 inventory)
+3. If the signal matches AND no existing agent covers it → candidate
+
+#### Concern-topology checks (carry-over)
+
 From Phase 2 concern topology:
 - Separate lint/test configs per subdirectory → specialized agent per domain
 - Security scanning tools in CI (Trivy, Snyk, CodeQL, gitleaks) → security-reviewer agent
 - Separate deployment targets (Terraform, Helm, CDK) → infra-architect agent
 - CODEOWNERS with clear responsibility boundaries → agent per ownership area
+
+#### Validation gate
 
 Decision: only recommend Agent if concern has BOTH its own toolchain AND its own evaluation criteria. Otherwise recommend Skill.
 
@@ -308,12 +322,26 @@ This is an intentionally conservative repo policy to avoid inflating agent count
 
 ### 4D: Hook/Rule Candidates
 
+#### Signal catalog checks (Rule track)
+
+Using the signal-catalog.md loaded in Phase 1, match Phase 2 scan results
+against the Rule Candidate Signal Table.
+
+For each signal row in the table:
+1. Check if the Detection Pattern matches Phase 2 findings
+2. Check if a corresponding rule already exists (from Phase 1 Step 2 inventory)
+3. If the signal matches AND no existing rule covers it → candidate
+
+#### Constraint-extraction checks (carry-over, both tracks)
+
 From Phase 2 constraint extraction:
 - Pre-commit hooks (.pre-commit-config.yaml, .husky/) → PostToolUse hooks for formatters
 - Branch protection rules → Rule ("Never commit directly to main")
 - Secret scanning in CI → PreToolUse hook for secret detection
 - .gitignore/.dockerignore patterns → file-write restriction rules
 - Mandatory review labels → permission config recommendation
+
+#### Validation gate
 
 Decision: if check is a single command with boolean output → Hook. If judgment needed → Rule.
 

--- a/skills/review-claude-config/references/signal-catalog.md
+++ b/skills/review-claude-config/references/signal-catalog.md
@@ -45,6 +45,24 @@ last_refreshed: 2026-04-03
 | No cross-skill dependency map | Skills cross-read sibling `references/`, undocumented | Dependency skill | W |
 | Research files without index | `research/` ≥5 files, no generated index | Research index skill | W |
 
+## Agent Candidate Signal Table
+
+| Signal | Detection Pattern | Agent Candidate | S |
+|--------|-------------------|-----------------|---|
+| Security scanning toolchain | `.github/workflows/*.{yml,yaml}` references Trivy / Snyk / CodeQL / gitleaks AND no `agents/security*` exists | `security-reviewer` agent | S |
+| Separate IaC deployment targets | ≥2 of `*.tf`, `helm/Chart.yaml`, `cdk.json`, `kustomization.yaml` AND no `agents/infra*` exists | `infra-architect` agent | S |
+| Database-migration toolchain isolated | `migrations/`, `alembic/`, or `prisma/migrations/` AND no `agents/migration*` exists | `migration-reviewer` agent | S |
+| Release-engineering toolchain isolated | `scripts/release*` + `.github/workflows/release*.yml` use a toolchain absent from `make test` | `release-engineer` agent | W |
+
+## Rule Candidate Signal Table
+
+| Signal | Detection Pattern | Rule Candidate | S |
+|--------|-------------------|----------------|---|
+| Branch-protection enforcement on `main` | `.github/branch_protection.json` OR repo policy prohibits direct push to `main`/`master` | `no-direct-push-to-main` rule | S |
+| Review-label routing requiring judgment | repo workflow requires PR labels (`needs: security-review`, `needs: arch-review`) selected by content judgment | `pr-review-label-routing` rule | M |
+| Sensitive-path write-restriction | `.gitignore`/`.dockerignore` patterns where exclusion rationale is non-mechanical (e.g., `secrets/`, `*.local.*`) | `sensitive-paths-write-restriction` rule | M |
+| Commit-message style requiring narrative judgment | `CONTRIBUTING.md` / `STYLE.md` clauses like "prefer X unless Y" — not single-command checkable | `commit-message-style` rule | M |
+
 ## Extraction Criteria
 
 Every suggestion must pass 3/4 ([source](https://arxiv.org/html/2603.11808v1)):

--- a/tests/test_validate_token_budgets.py
+++ b/tests/test_validate_token_budgets.py
@@ -39,7 +39,7 @@ class TestGetBudget:
         assert get_budget(tmp_path / "engineering-baseline.md") == 4350
 
     def test_signal_catalog(self, tmp_path):
-        assert get_budget(tmp_path / "signal-catalog.md") == 1000
+        assert get_budget(tmp_path / "signal-catalog.md") == 1400
 
     def test_domain_cache(self, tmp_path):
         p = tmp_path / "skills" / "x" / "references" / "domain-cache" / "cilium.md"


### PR DESCRIPTION
## Summary

- Extends `skills/review-claude-config/references/signal-catalog.md` with two new H2 sections — `Agent Candidate Signal Table` and `Rule Candidate Signal Table` — mirroring the existing Application/Skills Repository tables.
- Updates `skills/audit-repo/SKILL.md` §4C and §4D to read those tables BEFORE applying the existing conservative gates (signal-catalog read first, then policy filter), bringing them in line with §4B's table-driven structure.
- Bumps `signal-catalog.md` token budget from 1000 → 1400 in `scripts/validate_token_budgets.py` and the coupled assertion in `tests/test_validate_token_budgets.py` to accommodate the ~50% content addition.

Conservative-policy sentences in §4C (\`only recommend Agent if concern has BOTH its own toolchain AND its own evaluation criteria. Otherwise recommend Skill.\`) and §4D (\`single command with boolean output → Hook. If judgment needed → Rule.\`) preserved verbatim — Unicode `→` (U+2192) bytes preserved by Read+Edit, not retype.

Closes #160

## Test plan

- [x] AC1: `## Agent Candidate Signal Table` heading + schema match + ≥4 data rows (verified via grep)
- [x] AC2: `## Rule Candidate Signal Table` heading + schema match + ≥4 data rows
- [x] AC3: every primitive cell ends with `` `<finite-name>` agent `` or `` `<finite-name>` rule `` (verified via awk regex requiring backticked finite name)
- [x] AC4: §4C reads Agent Candidate Signal Table BEFORE conservative gate (ordering verified: p=6 < c=23)
- [x] AC5: §4D reads Rule Candidate Signal Table BEFORE conservative gate (ordering verified: p=6 < c=24)
- [x] AC6: conservative-policy sentences present verbatim
- [x] AC7: `make validate` exits 0 (975 tests pass)
- [x] AC8: `/review-skill skills/audit-repo/SKILL.md` shows zero new Medium+ findings caused by this diff (pre-existing FAILs unchanged)
- [ ] AC9: `/check-repo-health integrity` (Evaluator-deferred; defensive cross-file table-name diff already passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)