### PR TITLE
fix(ci): guard fromJSON against empty release-please pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Sync marketplace.json source.ref + plugins[0].version
         if: ${{ steps.release.outputs.pr != '' && !inputs.dry-run }}
         env:
-          PR_HEAD: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          PR_HEAD: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
           git fetch origin "$PR_HEAD"
@@ -66,7 +66,7 @@ jobs:
       - name: Auto-merge release PR (only when validation passed)
         if: ${{ steps.release.outputs.pr != '' && !inputs.dry-run }}
         env:
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          PR_NUMBER: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Defensive fix for the `release-please.yml` workflow.

GitHub Actions evaluates step `env:` blocks at step start, **independently of the `if:` condition**. The expression `${{ fromJSON(steps.release.outputs.pr).headBranchName }}` therefore fails template evaluation with `Error reading JToken from JsonReader. Path '', line 0, position 0` whenever `release-please-action` emits no release PR (push to `main` containing only `docs:` / `chore:` / `style:` / etc. — no bump-relevant content).

Wrap both occurrences (`PR_HEAD` in the sync step, `PR_NUMBER` in the auto-merge step) in a short-circuit:

```yaml
${{ steps.release.outputs.pr && fromJSON(...).field || '' }}
```

so the `fromJSON` call only runs when the output is non-empty. The `if:` condition still skips the step body in those cases — the wrapper just prevents the eager template-eval failure from aborting the whole run before any `if:` is checked.

This is the bug that caused run `25316579236` to fail with a JToken error during the v2.2.0 release cycle. The current happy path (with a release-PR) is unchanged — the second invocation just confirmed that yesterday by producing v2.3.0 in 44 seconds.

## Test plan

- [x] `make validate` green (985 tests pass).
- [ ] After merge: this PR is itself a `fix(ci):` commit so it will trigger a patch-level auto-release (`v2.3.0 → v2.3.1`) — that constitutes the post-merge smoke test for the patch path.
- [ ] Future docs-only or chore-only push to `main` no longer aborts the workflow with a JToken error; instead the workflow runs cleanly with all conditional steps skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
