### PR TITLE
refactor(scripts): extract 3 reader-script constants to YAML + schemas

### DIFF
--- a/scripts/audit_preflight.py
+++ b/scripts/audit_preflight.py
@@ -1,86 +1,80 @@
 #!/usr/bin/env python3
 """Preflight detector for non-deterministic LLM-binary rubric items.
 
-Items that require LLM judgment for a final verdict but whose *trigger*
-is regex-detectable. This script narrows the LLM-review surface by
-listing skills containing the trigger pattern — those are the only
-candidates the reviewer must judge.
-
 Items covered (regex preflight only — no PASS/FAIL verdict):
-- WS-7  Lexical-Overlap-Verification (trigger: "(if|when) the (file|...)
-        (contains|mentions|...)")
-- WS-8  Distractor-Isolation (trigger: ≥2 reference loads in same step)
-- GA-Y  Premise-Verification (trigger: body acts on user-supplied path/
-        command/claim)
-- GA-Z  Function-Goal-Alignment (trigger: success criteria use form-only
-        proxies)
-- GA-S  Anti-Gaming (trigger: review-class skill with regex criteria)
-- CE-CP Critical-Instruction-Placement (trigger: ≥150 lines + Hard Rules
-        section header)
-- SP-IO Indirect-Output-Validation (trigger: tool-output reference in step)
-- COMP-Sel Selection-Composition (trigger: ≥2 mutually-exclusive branches)
+WS-7, WS-8, GA-Y, GA-Z, GA-S, CE-CP, SP-IO, COMP-Sel.
+
+Trigger patterns are read from
+skills/review-claude-config/references/audit-triggers.yaml
+(override via AUDIT_TRIGGERS_YAML_PATH env var).
 
 Usage:
     python3 scripts/audit_preflight.py [--show-paths]
-
-Output: per-item count of trigger hits across skills/*/SKILL.md, with
-optional path listing.
 """
 
 from __future__ import annotations
 
+import functools
+import os
 import pathlib
 import re
 import sys
+
+import yaml
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 from rubric_binary_evaluator import REPO_ROOT  # noqa: E402
 
-# Trigger patterns (regex preflight only — verdict still requires LLM).
-TRIGGERS: dict[str, re.Pattern[str]] = {
-    "WS-7": re.compile(
-        r"(if|when)\s+the\s+(file|description|input|argument|user|content)\s+"
-        r"(contains|mentions|includes|has)\s+",
-        re.IGNORECASE,
-    ),
-    "GA-Y": re.compile(
-        # Body acts on user-supplied premise — proxy: $ARGUMENTS / user-supplied
-        # path/command without nearby validation/verification verb.
-        r"\$ARGUMENTS|user-supplied\s+(path|command|claim|input|file)",
-    ),
-    "GA-Z": re.compile(
-        # Success criteria using bare form-only proxies. Proxy regex: success
-        # condition mentioning count/exists without function-level verb.
-        r"complete\s+when[^.]{0,120}(exists|count|created|written|finished)",
-        re.IGNORECASE,
-    ),
-    "CE-CP": re.compile(
-        # Hard-Rules-class section header. Triggers only on ≥150-line bodies
-        # (filtered separately below).
-        r"^#{1,3}\s+(Hard\s+Rules?|Critical\s+Constraints?|Operational\s+Rules?)",
-        re.MULTILINE | re.IGNORECASE,
-    ),
-    "SP-IO": re.compile(
-        # Tool-output reference patterns.
-        r"output\s+of\s+(\w+)|result\s+from\s+(\w+)|"
-        r"returned\s+by\s+(\w+)|from\s+the\s+response|"
-        r"Bash\s+stdout|WebFetch\s+content",
-        re.IGNORECASE,
-    ),
-    "COMP-Sel": re.compile(
-        # ≥2 if branches in body — proxy: count of "if " at line start.
-        # Verdict requires LLM to judge mutual-exclusivity.
-        r"^\s*(?:[-*]?\s*)?if\s+",
-        re.MULTILINE | re.IGNORECASE,
-    ),
-}
-
-# WS-8 needs a separate count-based check (≥2 reference-load patterns per step).
-WS_8_REF_LOAD = re.compile(
-    r"references/[a-z_/-]+\.md|Read\s+[`'\"]?[a-z_/-]+\.md",
-    re.IGNORECASE,
+_DEFAULT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent / "skills/review-claude-config/references/audit-triggers.yaml"
 )
+
+
+def _yaml_path() -> str:
+    return os.environ.get("AUDIT_TRIGGERS_YAML_PATH", str(_DEFAULT_PATH))
+
+
+@functools.lru_cache(maxsize=4)
+def _load_cached(path: str) -> dict:
+    p = pathlib.Path(path)
+    if not p.exists():
+        raise RuntimeError(
+            f"audit-triggers.yaml missing at {p} — see "
+            f"skills/review-claude-config/references/schemas/audit-triggers.schema.json"
+        )
+    with p.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if data is None:
+        raise RuntimeError(f"audit-triggers.yaml at {p} is empty or invalid YAML")
+    return data
+
+
+def _load() -> dict:
+    return _load_cached(_yaml_path())
+
+
+def _flags(flag_names: list[str]) -> int:
+    """Convert list of flag name strings to re module flag bitmask."""
+    result = 0
+    for name in flag_names:
+        result |= getattr(re, name, 0)
+    return result
+
+
+_data = _load()
+
+# Eager-resolve at module import — preserves test-suite constant imports.
+TRIGGERS: dict[str, re.Pattern[str]] = {
+    t["id"]: re.compile(t["pattern"], _flags(t["flags"])) for t in _data["triggers"]
+}
+WS_8_REF_LOAD = re.compile(
+    _data["count_triggers"][0]["pattern"],
+    _flags(_data["count_triggers"][0].get("flags", [])),
+)
+_NOTES = {t["id"]: t["notes"] for t in (_data["triggers"] + _data["count_triggers"])}
+_ITEM_ORDER: list[str] = list(_data["item_order"])
+_GA_S_PREFIXES: tuple[str, ...] = tuple(_data["count_triggers"][1]["name_prefix_match"])
 
 
 def line_count(body: str) -> int:
@@ -113,35 +107,24 @@ def main(show_paths: bool = False) -> int:
                     continue  # NA exemption
                 hits[item].append(rel)
 
-        # WS-8: ≥2 reference loads in close proximity
+        # WS-8: >=2 reference loads in close proximity
         ref_matches = list(WS_8_REF_LOAD.finditer(body))
         if len(ref_matches) >= 2:
             hits["WS-8"].append(rel)
 
-        # GA-S: review-class skills (review/audit/classify/evaluate/score/certify)
+        # GA-S: review-class skills (review/audit/classify/evaluate)
         name_l = path.parent.name.lower()
-        if any(name_l.startswith(verb) for verb in ("review-", "audit-", "classify-", "evaluate-")):
+        if any(name_l.startswith(verb) for verb in _GA_S_PREFIXES):
             hits["GA-S"].append(rel)
 
-    notes = {
-        "WS-7": "lexical-overlap classification trigger; LLM verdicts schema-check presence",
-        "WS-8": "≥2 reference loads; LLM verdicts isolation-marker presence",
-        "GA-Y": "$ARGUMENTS or user-supplied premise; LLM verdicts validation predicate",
-        "GA-Z": "form-only success criteria; LLM verdicts function-level check",
-        "GA-S": "review-class skills (advisory); LLM verdicts evidence-grounding",
-        "CE-CP": "Hard Rules section in ≥150-line body; LLM verdicts placement",
-        "SP-IO": "tool-output → action chain; LLM verdicts sanitization",
-        "COMP-Sel": "≥2 if branches; LLM verdicts mutual-exclusivity + marker",
-    }
-
-    for item in ["WS-7", "WS-8", "GA-Y", "GA-Z", "GA-S", "CE-CP", "SP-IO", "COMP-Sel"]:
+    for item in _ITEM_ORDER:
         count = len(hits[item])
         flag = " ⚠️" if count > 0 else ""
-        print(f"| {item}{flag} | {count} | {notes[item]} |")
+        print(f"| {item}{flag} | {count} | {_NOTES[item]} |")
 
     if show_paths:
         print("\n## Candidate Skills per Item\n")
-        for item in ["WS-7", "WS-8", "GA-Y", "GA-Z", "GA-S", "CE-CP", "SP-IO", "COMP-Sel"]:
+        for item in _ITEM_ORDER:
             if hits[item]:
                 print(f"\n### {item} ({len(hits[item])} candidates)\n")
                 for p in hits[item]:

--- a/scripts/check_convergence.py
+++ b/scripts/check_convergence.py
@@ -2,17 +2,11 @@
 """Programmatic convergence checker for /review-skill Phase 5.
 
 Compares two ``merge_findings.py`` outputs ("run1" and "run2") and reports
-whether the two runs converged according to the contract in CLAUDE.md:126:
+whether the two runs converged according to the contract in CLAUDE.md:126.
 
-  1. **Deterministic subset match** — identical set of ``finding_id``s
-     whose ``checklist_item`` is in the deterministic subset
-     (``BINARY_ITEM_IDS | NARRATIVE_PARENT_IDS``) AND whose severity is
-     High or Medium.
-  2. **Grade variance ≤ 1 letter** in every dimension where both runs
-     produced a value.
-  3. **No null dimensions added** — a dimension that had a value in run1
-     must not be null in run2. (The reverse — gaining a dimension — is
-     treated as additional information, not a regression.)
+Constants are loaded from
+skills/review-claude-config/references/convergence-rules.yaml
+(override via CONVERGENCE_RULES_YAML_PATH env var).
 
 Exit codes:
   0 — converged (gate passes)
@@ -26,25 +20,49 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import functools
 import json
+import os
 import pathlib
 import sys
 
-# Source of truth for the deterministic subset lives in merge_findings.py.
-# Importing from there keeps the two files in lockstep — adding a new
-# binary item to BINARY_ITEM_IDS automatically extends the convergence
-# gate without requiring a parallel edit here.
-SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-sys.path.insert(0, str(SCRIPT_DIR))
-from merge_findings import BINARY_ITEM_IDS, NARRATIVE_PARENT_IDS  # noqa: E402
+import yaml
 
-DETERMINISTIC_SUBSET: frozenset[str] = BINARY_ITEM_IDS | NARRATIVE_PARENT_IDS
+_DEFAULT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent / "skills/review-claude-config/references/convergence-rules.yaml"
+)
 
-# A < B < C < D < F. F is "worst" in the standard letter scale.
-GRADE_LETTERS: tuple[str, ...] = ("A", "B", "C", "D", "F")
+
+def _yaml_path() -> str:
+    return os.environ.get("CONVERGENCE_RULES_YAML_PATH", str(_DEFAULT_PATH))
+
+
+@functools.lru_cache(maxsize=4)
+def _load_cached(path: str) -> dict:
+    p = pathlib.Path(path)
+    if not p.exists():
+        raise RuntimeError(
+            f"convergence-rules.yaml missing at {p} — see "
+            f"skills/review-claude-config/references/schemas/convergence-rules.schema.json"
+        )
+    with p.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if data is None:
+        raise RuntimeError(f"convergence-rules.yaml at {p} is empty or invalid YAML")
+    return data
+
+
+def _load() -> dict:
+    return _load_cached(_yaml_path())
+
+
+_data = _load()
+
+# Eager-resolve at module import with type coercion — preserves test-suite imports.
+DETERMINISTIC_SUBSET: frozenset[str] = frozenset(_data["DETERMINISTIC_SUBSET"])
+GRADE_LETTERS: tuple[str, ...] = tuple(_data["GRADE_LETTERS"])
 GRADE_RANK: dict[str, int] = {g: i for i, g in enumerate(GRADE_LETTERS)}
-
-DEFAULT_MAX_VARIANCE = 1
+DEFAULT_MAX_VARIANCE: int = int(_data["DEFAULT_MAX_VARIANCE"])
 
 
 def _deterministic_hm_finding_ids(merged: dict) -> set[str]:

--- a/scripts/escalation_decision.py
+++ b/scripts/escalation_decision.py
@@ -2,15 +2,19 @@
 """Decide whether a merged review certificate requires escalation.
 
 Rules (all decidable without an LLM call):
-  ESC-1: weighted_score within 2.5 points of any grade boundary (60/70/80/90).
+  ESC-1: weighted_score within ESC1_PROXIMITY of any GRADE_BOUNDARY.
   ESC-2: severity set contains "High" AND "Low" but NOT "Medium" (U-shape).
-  ESC-3: max-min perspective weighted-score divergence >=20 points
+  ESC-3: max-min perspective weighted-score divergence >= ESC3_DIVERGENCE
          (computed only over perspectives that produced a weighted_score).
          If fewer than 2 perspectives produced a score, ESC-3 is NULL (not
          triggered).
   ESC-4: --deep flag passed (external to this script — pass --deep to force).
   ESC-5: merged cert has degraded_mode=true (any perspective missing or
          malformed).
+
+Constants are loaded from
+skills/review-claude-config/references/escalation-rules.yaml
+(override via ESCALATION_RULES_YAML_PATH env var).
 
 Usage:
   python3 escalation_decision.py <merged-cert.json> [--deep]
@@ -24,13 +28,48 @@ Output (stdout): JSON:
 
 from __future__ import annotations
 
+import functools
 import json
+import os
 import pathlib
 import sys
 
-GRADE_BOUNDARIES = (60, 70, 80, 90)
-ESC1_PROXIMITY = 2.5
-ESC3_DIVERGENCE = 20.0
+import yaml
+
+_DEFAULT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent / "skills/review-claude-config/references/escalation-rules.yaml"
+)
+
+
+def _yaml_path() -> str:
+    return os.environ.get("ESCALATION_RULES_YAML_PATH", str(_DEFAULT_PATH))
+
+
+@functools.lru_cache(maxsize=4)
+def _load_cached(path: str) -> dict:
+    p = pathlib.Path(path)
+    if not p.exists():
+        raise RuntimeError(
+            f"escalation-rules.yaml missing at {p} — see "
+            f"skills/review-claude-config/references/schemas/escalation-rules.schema.json"
+        )
+    with p.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if data is None:
+        raise RuntimeError(f"escalation-rules.yaml at {p} is empty or invalid YAML")
+    return data
+
+
+def _load() -> dict:
+    return _load_cached(_yaml_path())
+
+
+_data = _load()
+
+# Eager-resolve at module import with type coercion — preserves test-suite imports.
+GRADE_BOUNDARIES: tuple[int, ...] = tuple(_data["GRADE_BOUNDARIES"])
+ESC1_PROXIMITY: float = float(_data["ESC1_PROXIMITY"])
+ESC3_DIVERGENCE: float = float(_data["ESC3_DIVERGENCE"])
 
 
 def decide(merged: dict, deep_flag: bool = False) -> dict:

--- a/scripts/validate_schema.py
+++ b/scripts/validate_schema.py
@@ -322,6 +322,70 @@ def validate_hooks_json() -> list[str]:
     return errors
 
 
+YAML_REF_ALLOWLIST = ("audit-triggers.yaml", "convergence-rules.yaml", "escalation-rules.yaml")
+
+
+def validate_yaml_reference_files() -> list[str]:
+    """Validate maintainer-edited YAML references against schemas + cross-YAML invariants.
+
+    Distinct from merge-policy.yaml (auto-generated; validated separately by
+    scripts/regenerate_merge_policy.py). Allowlist-based to prevent accidental
+    inclusion of new yamls without explicit registration.
+
+    Cross-YAML invariant: convergence-rules.yaml::DETERMINISTIC_SUBSET MUST equal
+    merge-policy.yaml::binary_item_ids | narrative_parent_ids. Detects drift on
+    every make validate.
+    """
+    import jsonschema
+
+    errors: list[str] = []
+    refs_dir = REPO_ROOT / "skills" / "review-claude-config" / "references"
+    schemas_dir = refs_dir / "schemas"
+    yaml_data: dict[str, dict] = {}
+
+    for stem_yaml in YAML_REF_ALLOWLIST:
+        yaml_path = refs_dir / stem_yaml
+        if not yaml_path.exists():
+            errors.append(f"{yaml_path}: file not found (registered in YAML_REF_ALLOWLIST)")
+            continue
+        schema_path = schemas_dir / f"{yaml_path.stem}.schema.json"
+        if not schema_path.exists():
+            errors.append(f"{yaml_path}: no schema found at {schema_path}")
+            continue
+        try:
+            data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, json.JSONDecodeError) as e:
+            errors.append(f"{yaml_path}: invalid — {e}")
+            continue
+        if data is None:
+            errors.append(f"{yaml_path}: empty or invalid YAML")
+            continue
+        for error in jsonschema.Draft202012Validator(schema).iter_errors(data):
+            errors.append(f"{yaml_path}: {error.message} at {error.json_path}")
+        yaml_data[yaml_path.stem] = data
+
+    # Cross-YAML invariant: DETERMINISTIC_SUBSET drift check
+    conv = yaml_data.get("convergence-rules")
+    if conv is not None and "DETERMINISTIC_SUBSET" in conv:
+        merge_policy_path = REPO_ROOT / "skills" / "review-skill" / "references" / "merge-policy.yaml"
+        if merge_policy_path.exists():
+            try:
+                mp = yaml.safe_load(merge_policy_path.read_text(encoding="utf-8"))
+                expected = frozenset(mp.get("binary_item_ids", [])) | frozenset(mp.get("narrative_parent_ids", []))
+                actual = frozenset(conv["DETERMINISTIC_SUBSET"])
+                if actual != expected:
+                    missing = sorted(expected - actual)
+                    extra = sorted(actual - expected)
+                    errors.append(
+                        f"convergence-rules.yaml: DETERMINISTIC_SUBSET drift vs merge-policy.yaml — "
+                        f"missing={missing!r}, extra={extra!r}"
+                    )
+            except yaml.YAMLError as e:
+                errors.append(f"merge-policy.yaml: cannot read for drift check — {e}")
+    return errors
+
+
 def main() -> int:
     all_errors: list[str] = []
 
@@ -333,6 +397,7 @@ def main() -> int:
         ("Domain cache files", validate_domain_cache_files),
         ("hooks.json", validate_hooks_json),
         ("Hook config files", validate_hook_config_files),
+        ("YAML reference files", validate_yaml_reference_files),
     ]
 
     for label, validator in validators:

--- a/skills/review-claude-config/references/audit-triggers.yaml
+++ b/skills/review-claude-config/references/audit-triggers.yaml
@@ -1,0 +1,40 @@
+# Maintainer-edited — controls scripts/audit_preflight.py preflight detector.
+# Patterns are *code-equivalent*: review changes with the same rigor as Python.
+# Schema: skills/review-claude-config/references/schemas/audit-triggers.schema.json
+policy_version: '1.0'
+triggers:
+  - id: WS-7
+    pattern: "(if|when)\\s+the\\s+(file|description|input|argument|user|content)\\s+(contains|mentions|includes|has)\\s+"
+    flags: [IGNORECASE]
+    notes: "lexical-overlap classification trigger; LLM verdicts schema-check presence"
+  - id: GA-Y
+    pattern: "\\$ARGUMENTS|user-supplied\\s+(path|command|claim|input|file)"
+    flags: []
+    notes: "$ARGUMENTS or user-supplied premise; LLM verdicts validation predicate"
+  - id: GA-Z
+    pattern: "complete\\s+when[^.]{0,120}(exists|count|created|written|finished)"
+    flags: [IGNORECASE]
+    notes: "form-only success criteria; LLM verdicts function-level check"
+  - id: CE-CP
+    pattern: "^#{1,3}\\s+(Hard\\s+Rules?|Critical\\s+Constraints?|Operational\\s+Rules?)"
+    flags: [MULTILINE, IGNORECASE]
+    line_count_min: 150
+    notes: "Hard Rules section in 150-plus line body; LLM verdicts placement"
+  - id: SP-IO
+    pattern: "output\\s+of\\s+(\\w+)|result\\s+from\\s+(\\w+)|returned\\s+by\\s+(\\w+)|from\\s+the\\s+response|Bash\\s+stdout|WebFetch\\s+content"
+    flags: [IGNORECASE]
+    notes: "tool-output to action chain; LLM verdicts sanitization"
+  - id: COMP-Sel
+    pattern: "^\\s*(?:[-*]?\\s*)?if\\s+"
+    flags: [MULTILINE, IGNORECASE]
+    notes: "two-or-more if branches; LLM verdicts mutual-exclusivity + marker"
+count_triggers:
+  - id: WS-8
+    pattern: "references/[a-z_/-]+\\.md|Read\\s+[`'\"']?[a-z_/-]+\\.md"
+    flags: [IGNORECASE]
+    min_matches: 2
+    notes: "two-or-more reference loads; LLM verdicts isolation-marker presence"
+  - id: GA-S
+    name_prefix_match: ["review-", "audit-", "classify-", "evaluate-"]
+    notes: "review-class skills (advisory); LLM verdicts evidence-grounding"
+item_order: [WS-7, WS-8, GA-Y, GA-Z, GA-S, CE-CP, SP-IO, COMP-Sel]

--- a/skills/review-claude-config/references/convergence-rules.yaml
+++ b/skills/review-claude-config/references/convergence-rules.yaml
@@ -1,0 +1,57 @@
+# Maintainer-edited — controls scripts/check_convergence.py convergence gate.
+# DETERMINISTIC_SUBSET MUST equal binary_item_ids | narrative_parent_ids in
+# skills/review-skill/references/merge-policy.yaml. Drift is enforced by
+# scripts/validate_schema.py::validate_yaml_reference_files() (cross-YAML check).
+# Schema: skills/review-claude-config/references/schemas/convergence-rules.schema.json
+policy_version: '1.0'
+DETERMINISTIC_SUBSET:
+  # Materialised as the union of merge-policy.yaml binary_item_ids | narrative_parent_ids.
+  # The validator detects drift on every make validate run.
+  - AH-2
+  - AH-2b
+  - CE-X
+  - CLAR-1
+  - CLAR-2
+  - CLAR-3
+  - CLAR-4
+  - COMP-V
+  - COMP-W
+  - COMP-X
+  - COMP-Y
+  - COMP-Z
+  - IJ-1
+  - IJ-1b
+  - META-1
+  - META-1a
+  - META-2
+  - META-3
+  - META-3a
+  - META-3b
+  - META-3c
+  - META-4
+  - PE-1
+  - PE-2
+  - RD-5
+  - RD-5b
+  - RL-1
+  - RL-1b
+  - RL-3
+  - RL-3b
+  - RL-4
+  - RL-4b
+  - RL-9
+  - RL-9b
+  - SAMP-1
+  - SAMP-2
+  - SP-2
+  - SP-2b
+  - SP-4
+  - SP-4b
+  - WS-2
+  - WS-2b
+  - WS-4
+  - WS-5
+  - WS-5b
+  - WS-6
+GRADE_LETTERS: [A, B, C, D, F]
+DEFAULT_MAX_VARIANCE: 1

--- a/skills/review-claude-config/references/escalation-rules.yaml
+++ b/skills/review-claude-config/references/escalation-rules.yaml
@@ -1,0 +1,6 @@
+# Maintainer-edited — controls scripts/escalation_decision.py escalation triggers.
+# Schema: skills/review-claude-config/references/schemas/escalation-rules.schema.json
+policy_version: '1.0'
+GRADE_BOUNDARIES: [60, 70, 80, 90]
+ESC1_PROXIMITY: 2.5
+ESC3_DIVERGENCE: 20.0

--- a/skills/review-claude-config/references/schemas/audit-triggers.schema.json
+++ b/skills/review-claude-config/references/schemas/audit-triggers.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "audit-triggers.schema.json",
+  "title": "Audit Triggers",
+  "description": "Schema for audit-triggers.yaml — controls audit_preflight.py preflight detector.",
+  "type": "object",
+  "required": ["policy_version", "triggers", "count_triggers", "item_order"],
+  "additionalProperties": false,
+  "properties": {
+    "policy_version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "pattern", "flags", "notes"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "flags": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": ["IGNORECASE", "MULTILINE", "DOTALL"]
+            }
+          },
+          "notes": {
+            "type": "string",
+            "pattern": "^[^|`]+$",
+            "maxLength": 200
+          },
+          "line_count_min": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "count_triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "notes"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "flags": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": ["IGNORECASE", "MULTILINE", "DOTALL"]
+            }
+          },
+          "min_matches": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "name_prefix_match": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "notes": {
+            "type": "string",
+            "pattern": "^[^|`]+$",
+            "maxLength": 200
+          }
+        }
+      }
+    },
+    "item_order": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/skills/review-claude-config/references/schemas/convergence-rules.schema.json
+++ b/skills/review-claude-config/references/schemas/convergence-rules.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "convergence-rules.schema.json",
+  "title": "Convergence Rules",
+  "description": "Schema for convergence-rules.yaml — controls check_convergence.py convergence gate.",
+  "type": "object",
+  "required": ["policy_version", "DETERMINISTIC_SUBSET", "GRADE_LETTERS", "DEFAULT_MAX_VARIANCE"],
+  "additionalProperties": false,
+  "properties": {
+    "policy_version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "DETERMINISTIC_SUBSET": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "GRADE_LETTERS": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "DEFAULT_MAX_VARIANCE": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/skills/review-claude-config/references/schemas/escalation-rules.schema.json
+++ b/skills/review-claude-config/references/schemas/escalation-rules.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "escalation-rules.schema.json",
+  "title": "Escalation Rules",
+  "description": "Schema for escalation-rules.yaml — controls escalation_decision.py escalation triggers.",
+  "type": "object",
+  "required": ["policy_version", "GRADE_BOUNDARIES", "ESC1_PROXIMITY", "ESC3_DIVERGENCE"],
+  "additionalProperties": false,
+  "properties": {
+    "policy_version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "GRADE_BOUNDARIES": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100
+      }
+    },
+    "ESC1_PROXIMITY": {
+      "type": "number",
+      "minimum": 0
+    },
+    "ESC3_DIVERGENCE": {
+      "type": "number",
+      "minimum": 0
+    }
+  }
+}

--- a/tests/test_validate_schema.py
+++ b/tests/test_validate_schema.py
@@ -582,12 +582,87 @@ class TestValidateHooksJson:
 class TestValidateMain:
     def _setup_valid_repo(self, tmp_path):
         """Create minimal valid structure for all validators to pass."""
+        import json as _json
+
+        import yaml as _yaml
+
         # Reference files
         refs = tmp_path / "skills" / "review-claude-config" / "references"
+        schemas = refs / "schemas"
         refs.mkdir(parents=True)
+        schemas.mkdir()
         (refs / "ref.md").write_text(
             "---\nname: r\ndescription: a description that meets the minimum length\nlast_refreshed: 2026-01-01\n---\n"
         )
+        # YAML reference files (validate_yaml_reference_files allowlist)
+        audit_yaml = {
+            "policy_version": "1.0",
+            "triggers": [{"id": "WS-7", "pattern": "foo", "flags": [], "notes": "test trigger"}],
+            "count_triggers": [
+                {"id": "WS-8", "pattern": "bar", "flags": ["IGNORECASE"], "min_matches": 2, "notes": "count test"},
+                {"id": "GA-S", "name_prefix_match": ["review-"], "notes": "ga-s test"},
+            ],
+            "item_order": ["WS-7", "WS-8", "GA-S"],
+        }
+        audit_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["policy_version", "triggers", "count_triggers", "item_order"],
+            "properties": {
+                "policy_version": {"type": "string", "const": "1.0"},
+                "triggers": {"type": "array"},
+                "count_triggers": {"type": "array"},
+                "item_order": {"type": "array"},
+            },
+        }
+        (refs / "audit-triggers.yaml").write_text(_yaml.dump(audit_yaml), encoding="utf-8")
+        (schemas / "audit-triggers.schema.json").write_text(_json.dumps(audit_schema), encoding="utf-8")
+
+        conv_yaml = {
+            "policy_version": "1.0",
+            "DETERMINISTIC_SUBSET": ["CLAR-1"],
+            "GRADE_LETTERS": ["A", "B", "C", "D", "F"],
+            "DEFAULT_MAX_VARIANCE": 1,
+        }
+        conv_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["policy_version", "DETERMINISTIC_SUBSET", "GRADE_LETTERS", "DEFAULT_MAX_VARIANCE"],
+            "additionalProperties": False,
+            "properties": {
+                "policy_version": {"type": "string", "const": "1.0"},
+                "DETERMINISTIC_SUBSET": {"type": "array", "minItems": 1, "uniqueItems": True,
+                                         "items": {"type": "string", "minLength": 1}},
+                "GRADE_LETTERS": {"type": "array", "minItems": 5, "uniqueItems": True,
+                                  "items": {"type": "string", "minLength": 1}},
+                "DEFAULT_MAX_VARIANCE": {"type": "integer", "minimum": 0},
+            },
+        }
+        (refs / "convergence-rules.yaml").write_text(_yaml.dump(conv_yaml), encoding="utf-8")
+        (schemas / "convergence-rules.schema.json").write_text(_json.dumps(conv_schema), encoding="utf-8")
+
+        # Note: merge-policy.yaml not present in tmp_path → drift check is skipped gracefully
+        esc_yaml = {
+            "policy_version": "1.0",
+            "GRADE_BOUNDARIES": [60, 70, 80, 90],
+            "ESC1_PROXIMITY": 2.5,
+            "ESC3_DIVERGENCE": 20.0,
+        }
+        esc_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["policy_version", "GRADE_BOUNDARIES", "ESC1_PROXIMITY", "ESC3_DIVERGENCE"],
+            "additionalProperties": False,
+            "properties": {
+                "policy_version": {"type": "string", "const": "1.0"},
+                "GRADE_BOUNDARIES": {"type": "array", "minItems": 1, "items": {"type": "integer"}},
+                "ESC1_PROXIMITY": {"type": "number"},
+                "ESC3_DIVERGENCE": {"type": "number"},
+            },
+        }
+        (refs / "escalation-rules.yaml").write_text(_yaml.dump(esc_yaml), encoding="utf-8")
+        (schemas / "escalation-rules.schema.json").write_text(_json.dumps(esc_schema), encoding="utf-8")
+
         # Hooks json (no script refs to resolve)
         hooks_dir = tmp_path / "hooks"
         hooks_dir.mkdir()

--- a/tests/test_validate_yaml_reference_files.py
+++ b/tests/test_validate_yaml_reference_files.py
@@ -1,0 +1,168 @@
+"""Tests for validate_schema.validate_yaml_reference_files().
+
+Covers: all-present+consistent → [], schema missing, yaml malformed,
+schema-violation (policy_version const), and cross-YAML drift detection.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from validate_schema import validate_yaml_reference_files  # noqa: E402
+
+
+MERGE_POLICY_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "skills" / "review-skill" / "references" / "merge-policy.yaml"
+)
+
+
+def _make_refs_dir(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    """Create skills/review-claude-config/references/schemas/ under tmp_path."""
+    refs = tmp_path / "skills" / "review-claude-config" / "references"
+    schemas = refs / "schemas"
+    refs.mkdir(parents=True)
+    schemas.mkdir()
+    return refs, schemas
+
+
+def test_all_present_and_consistent():
+    """Real YAML + schema files pass with no errors."""
+    errors = validate_yaml_reference_files()
+    assert errors == [], f"Unexpected errors: {errors}"
+
+
+def test_schema_missing(tmp_path, monkeypatch):
+    """When a schema is absent, error contains 'no schema found'."""
+    refs, schemas = _make_refs_dir(tmp_path)
+    yaml_content = {
+        "policy_version": "1.0",
+        "GRADE_LETTERS": ["A", "B", "C", "D", "F"],
+        "DEFAULT_MAX_VARIANCE": 1,
+        "DETERMINISTIC_SUBSET": ["CLAR-1"],
+    }
+    (refs / "convergence-rules.yaml").write_text(yaml.dump(yaml_content), encoding="utf-8")
+    # No convergence-rules.schema.json → "no schema found"
+
+    import validate_schema as vs
+    monkeypatch.setattr(vs, "REPO_ROOT", tmp_path)
+    errors = validate_yaml_reference_files()
+    assert any("no schema found" in e for e in errors), f"Expected 'no schema found' in: {errors}"
+
+
+def test_yaml_malformed(tmp_path, monkeypatch):
+    """When a yaml file is malformed, error contains 'invalid'."""
+    refs, schemas = _make_refs_dir(tmp_path)
+
+    esc_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["policy_version", "GRADE_BOUNDARIES", "ESC1_PROXIMITY", "ESC3_DIVERGENCE"],
+        "additionalProperties": False,
+        "properties": {
+            "policy_version": {"type": "string", "const": "1.0"},
+            "GRADE_BOUNDARIES": {"type": "array", "minItems": 1, "items": {"type": "integer"}},
+            "ESC1_PROXIMITY": {"type": "number"},
+            "ESC3_DIVERGENCE": {"type": "number"},
+        },
+    }
+    (schemas / "escalation-rules.schema.json").write_text(json.dumps(esc_schema), encoding="utf-8")
+    # Write YAML that will fail yaml.safe_load by using a disallowed tag
+    (refs / "escalation-rules.yaml").write_text(
+        "policy_version: !!python/object:os.system 'bad'", encoding="utf-8"
+    )
+
+    import validate_schema as vs
+    monkeypatch.setattr(vs, "REPO_ROOT", tmp_path)
+    errors = validate_yaml_reference_files()
+    assert any("invalid" in e.lower() or "file not found" in e for e in errors), (
+        f"Expected invalid or file-not-found error in: {errors}"
+    )
+
+
+def test_schema_violation_policy_version(tmp_path, monkeypatch):
+    """A wrong policy_version const is rejected with the field path in the error."""
+    refs, schemas = _make_refs_dir(tmp_path)
+
+    bad_yaml = {
+        "policy_version": "2.0",  # schema requires const '1.0'
+        "GRADE_BOUNDARIES": [60, 70, 80, 90],
+        "ESC1_PROXIMITY": 2.5,
+        "ESC3_DIVERGENCE": 20.0,
+    }
+    esc_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["policy_version", "GRADE_BOUNDARIES", "ESC1_PROXIMITY", "ESC3_DIVERGENCE"],
+        "additionalProperties": False,
+        "properties": {
+            "policy_version": {"type": "string", "const": "1.0"},
+            "GRADE_BOUNDARIES": {"type": "array", "minItems": 1, "items": {"type": "integer"}},
+            "ESC1_PROXIMITY": {"type": "number"},
+            "ESC3_DIVERGENCE": {"type": "number"},
+        },
+    }
+    (refs / "escalation-rules.yaml").write_text(yaml.dump(bad_yaml), encoding="utf-8")
+    (schemas / "escalation-rules.schema.json").write_text(json.dumps(esc_schema), encoding="utf-8")
+
+    import validate_schema as vs
+    monkeypatch.setattr(vs, "REPO_ROOT", tmp_path)
+    errors = validate_yaml_reference_files()
+    # Should have a schema-violation error mentioning policy_version
+    assert any("policy_version" in e or "$.policy_version" in e for e in errors), (
+        f"Expected policy_version schema violation in: {errors}"
+    )
+
+
+def test_deterministic_subset_drift(tmp_path, monkeypatch):
+    """When DETERMINISTIC_SUBSET diverges from merge-policy union, error contains 'DETERMINISTIC_SUBSET drift'."""
+    refs, schemas = _make_refs_dir(tmp_path)
+
+    conv_yaml = {
+        "policy_version": "1.0",
+        "DETERMINISTIC_SUBSET": ["FAKE-1", "FAKE-2"],  # does not match merge-policy union
+        "GRADE_LETTERS": ["A", "B", "C", "D", "F"],
+        "DEFAULT_MAX_VARIANCE": 1,
+    }
+    conv_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["policy_version", "DETERMINISTIC_SUBSET", "GRADE_LETTERS", "DEFAULT_MAX_VARIANCE"],
+        "additionalProperties": False,
+        "properties": {
+            "policy_version": {"type": "string", "const": "1.0"},
+            "DETERMINISTIC_SUBSET": {
+                "type": "array", "minItems": 1, "uniqueItems": True,
+                "items": {"type": "string", "minLength": 1},
+            },
+            "GRADE_LETTERS": {
+                "type": "array", "minItems": 5, "uniqueItems": True,
+                "items": {"type": "string", "minLength": 1},
+            },
+            "DEFAULT_MAX_VARIANCE": {"type": "integer", "minimum": 0},
+        },
+    }
+    (refs / "convergence-rules.yaml").write_text(yaml.dump(conv_yaml), encoding="utf-8")
+    (schemas / "convergence-rules.schema.json").write_text(json.dumps(conv_schema), encoding="utf-8")
+
+    # Copy the real merge-policy.yaml into tmp_path for the drift check
+    review_skill_refs = tmp_path / "skills" / "review-skill" / "references"
+    review_skill_refs.mkdir(parents=True)
+    (review_skill_refs / "merge-policy.yaml").write_text(
+        MERGE_POLICY_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    import validate_schema as vs
+    monkeypatch.setattr(vs, "REPO_ROOT", tmp_path)
+    errors = validate_yaml_reference_files()
+    assert any("DETERMINISTIC_SUBSET drift" in e for e in errors), (
+        f"Expected DETERMINISTIC_SUBSET drift error in: {errors}"
+    )


### PR DESCRIPTION
## Summary

- Extract maintainer-edited constants from `audit_preflight.py`, `check_convergence.py`, `escalation_decision.py` to YAML references with JSON-Schema validation
- Predicate logic stays in code per Right-Altitude L82-84 carve-out
- Adds cross-YAML drift detection in `validate_schema.py` between `convergence-rules.yaml::DETERMINISTIC_SUBSET` and `merge-policy.yaml::binary_item_ids|narrative_parent_ids`

## Scope decisions

- **AC#3 (LOC ≤100/100/100) DROPPED** per maintainer authorisation (3rd issue in Stufe-2 series hitting the same satisfiability floor; see issue #191 comments).
- All other ACs (#1, #2, #4, #5, #6) PASS.
- Test files \`tests/test_audit_scripts_smoke.py\`, \`tests/test_convergence.py\`, \`tests/test_escalation_decision.py\` unchanged (AC#5 freeze).

## Test plan

- [x] make validate (1001 passed, 6 warnings, 0 failures)
- [x] AC#5 freeze: \`git diff --name-only HEAD~1 -- tests/test_audit_scripts_smoke.py tests/test_convergence.py tests/test_escalation_decision.py\` empty
- [x] CLI contracts preserved (--show-paths, --help, exit-code semantics)
- [x] DETERMINISTIC_SUBSET cross-YAML drift detection green at write time
- [x] New test \`tests/test_validate_yaml_reference_files.py\` covers schema-missing, yaml-malformed, schema-violation, drift cases

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)