### PR TITLE
feat(scripts): add SF-3 peer-reference body-check for agent rubric

### DIFF
--- a/scripts/regenerate_merge_policy.py
+++ b/scripts/regenerate_merge_policy.py
@@ -25,11 +25,11 @@ RUBRIC = REPO_ROOT / "skills/review-claude-config/references/scoring-rubric.md"
 YAML_OUT = REPO_ROOT / "skills/review-skill/references/merge-policy.yaml"
 
 EXPECTED_COUNTS: dict[str, int] = {
-    "binary_item_ids": 32,
+    "binary_item_ids": 33,
     "narrative_parent_ids": 15,
-    "item_dimension": 33,
+    "item_dimension": 34,
     "binary_caps": 22,
-    "agent_item_dimension": 35,
+    "agent_item_dimension": 36,
 }
 
 HEADER_LINES = (
@@ -97,8 +97,8 @@ def parse_rubric(text: str) -> dict:
     """
     lines = text.splitlines(keepends=True)
 
-    # 1) §Item Inventory → ###Binary-Evaluated Items (32 rows: Item | Dimension)
-    binary_idx = _find_table(lines, "Item Inventory", "Binary-Evaluated Items (skill rubric, 32)")
+    # 1) §Item Inventory → ###Binary-Evaluated Items (33 rows: Item | Dimension)
+    binary_idx = _find_table(lines, "Item Inventory", "Binary-Evaluated Items (skill rubric, 33)")
     binary_rows = _parse_pipe_table(lines, binary_idx)
     binary_item_ids: list[str] = [r[0] for r in binary_rows if r and r[0]]
     item_dimension: dict[str, str] = {}
@@ -130,7 +130,7 @@ def parse_rubric(text: str) -> dict:
         if len(r) >= 3 and r[0]:
             binary_caps.append({"item": r[0], "dimension": r[1], "cap": r[2]})
 
-    # 4) §Agent Items (35 rows: Item | Dimension)
+    # 4) §Agent Items (36 rows: Item | Dimension)
     agent_idx = _find_table(lines, "Agent Items")
     agent_rows = _parse_pipe_table(lines, agent_idx)
     agent_item_dimension: dict[str, str] = {}

--- a/scripts/rubric_binary_evaluator.py
+++ b/scripts/rubric_binary_evaluator.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Deterministic binary-rubric evaluator for Claude Code skills and agents.
 
-Produces PASS / FAIL / NA verdicts for 28 binary-verifiable rubric items
+Produces PASS / FAIL / NA verdicts for 29 binary-verifiable rubric items
 against a single skill or agent artifact. Written JSON to stdout. Moves
 regex execution out of the LLM prompt so every perspective reviewer sees
 byte-identical verdicts, eliminating the ~80% run-to-run variance
 observed in the /review-skill convergence retest.
 
 Scope:
-  * skills/<name>/SKILL.md — all 28 items evaluated (full scope).
-  * agents/*.md — 26 items evaluated; COMP-X and META-3b return NA
+  * skills/<name>/SKILL.md — 28 of 29 items evaluated; SF-3 returns NA (agent-only scope).
+  * agents/*.md — 27 items evaluated; COMP-X and META-3b return NA
     because the rubric clauses encode skill-semantics (review-skill
     convergence predicate; skills/*/SKILL.md sibling glob). Full
     agent-semantic coverage (TC-3 for COMP-X analogue, agent-namespace
@@ -22,7 +22,7 @@ Usage:
     python3 scripts/rubric_binary_evaluator.py <absolute-artifact-path>
 
 Exit codes:
-    0 — evaluator ran, stats.runner_error == 0 (all 28 items produced a
+    0 — evaluator ran, stats.runner_error == 0 (all 29 items produced a
         verdict). Also used by argparse --help per GNU convention, which
         downstream consumers disambiguate by checking for the
         "schema_version" key in stdout JSON.
@@ -95,12 +95,14 @@ from rubric_patterns import (  # noqa: E402
     WS_6_ANCHOR,
     WS_6_ANCHOR_WINDOW,
     WS_6_COMPARATOR,
+    build_peer_agent_re,
     is_third_person,
     passes_clar1,
     passes_clar2,
     rd_5b_has_mapping_clause,
     rd_5b_schemes_present,
     strip_code,
+    strip_code_preserve_lines,
 )
 
 SCHEMA_VERSION = 1
@@ -734,6 +736,41 @@ def find_sibling_skills(path: pathlib.Path) -> list[pathlib.Path]:
         return []
     self_resolved = path.resolve()
     return [p for p in sorted(skills_root.glob("*/SKILL.md")) if p.resolve() != self_resolved]
+
+
+def discover_peer_agent_names(path: pathlib.Path) -> frozenset:
+    """Discover sibling agent names from the same agents/ directory.
+
+    Algorithm: agent files live at <root>/agents/<name>.md or
+    <root>/.claude/agents/<name>.md (single-level layout, distinct from
+    skills/<name>/SKILL.md two-level layout). The peer set is
+    ``path.resolve().parent.glob("*.md")`` minus self.
+
+    Cross-namespace peers (top-level agents/ vs .claude/agents/) are NOT
+    considered siblings — they are separate plugin distribution surfaces.
+
+    Bounds defend against FP-storm and ReDoS amplification:
+      - min-length 3: single/double-letter names produce lint storms in body prose.
+      - max-length 64: pathological long names cap regex-alternation size.
+      - cap 50 siblings: discovery count ceiling.
+    """
+    agents_dir = path.resolve().parent
+    if not agents_dir.exists() or agents_dir.name != "agents":
+        return frozenset()
+    names: set[str] = set()
+    for sibling in sorted(agents_dir.glob("*.md")):
+        if sibling.resolve() == path.resolve():
+            continue
+        try:
+            fm, _ = parse_frontmatter(sibling)
+        except Exception:
+            continue  # malformed sibling: skip silently, not an SF-3 concern
+        name = (fm.get("name") or sibling.stem).strip().lower()
+        if 3 <= len(name) <= 64:
+            names.add(name)
+        if len(names) >= 50:
+            break  # discovery-count cap
+    return frozenset(names)
 
 
 def line_of_offset(text: str, offset: int) -> int:
@@ -1502,6 +1539,85 @@ def check_AH_2b(body: str) -> dict:
     )
 
 
+def check_SF_3(path: pathlib.Path, body: str, fm: dict, artifact_type: str = "agent") -> dict:
+    """SF-3 (issue-spec name: A1) — flag peer-agent name occurrences in agent body.
+
+    See agent-evaluation-guide.md SF-3 row and research/agent-skills/peer-reference-anti-pattern.md.
+    Skills are orchestrators by design and are exempt (return NA).
+
+    Detection algorithm:
+      1. Discover sibling agent names via discover_peer_agent_names().
+      2. Strip fenced code blocks (preserving line numbers) via strip_code_preserve_lines().
+      3. Match peer names using a hyphen-resistant word-boundary regex.
+      4. Bare 'reviewer' token without '.md' within 30 chars is downgraded to WARN (human-role
+         disambiguation) rather than FAIL — avoids false positives from human-role mentions.
+    """
+    if artifact_type != "agent":
+        return _na("SF-3 only applies to agent artifacts")
+    own_name = (fm.get("name") or path.stem).strip().lower()
+    peer_names = discover_peer_agent_names(path) - {own_name}
+    if not peer_names:
+        return _na("no sibling agents discoverable")
+    pattern = build_peer_agent_re(peer_names)
+    if pattern is None:
+        return _na("empty peer set")
+
+    # Derive frontmatter line count by subtraction so reported lines are file-absolute.
+    # split_content returns (full_text, body), not (frontmatter_text, body).
+    # frontmatter_line_count = full_text lines - body lines gives the correct offset.
+    full_text = path.read_text(encoding="utf-8")
+    _, body_check = split_content(path)
+    assert body_check == body, "body / split_content mismatch — caller-side bug"
+    frontmatter_line_count = full_text.count("\n") - body.count("\n")
+
+    stripped = strip_code_preserve_lines(body)
+    matches: list[dict] = []
+    for m in pattern.finditer(stripped):
+        token = m.group(0).lower()
+        # Use stripped coordinates — strip_code_preserve_lines preserves newline
+        # positions so line_of_offset(stripped, m.start()) == line number in raw body.
+        stripped_line = line_of_offset(stripped, m.start())
+        # Bare 'reviewer' human-role disambiguation (AC4b):
+        # if matched word is 'reviewer' AND no '.md' in the next 30 chars → WARN.
+        if token == "reviewer":
+            window = stripped[m.end() : m.end() + 30]
+            if ".md" not in window:
+                matches.append(
+                    {
+                        "kind": "warn",
+                        "line": stripped_line + frontmatter_line_count,
+                        "matched_token": m.group(0),
+                        "reason": "human-role-disambiguation-needed",
+                    }
+                )
+                continue
+        matches.append(
+            {
+                "kind": "fail",
+                "line": stripped_line + frontmatter_line_count,
+                "matched_token": m.group(0),
+            }
+        )
+
+    if not matches:
+        return _pass()
+    fail_matches = [x for x in matches if x["kind"] == "fail"]
+    if fail_matches:
+        return {
+            "verdict": "FAIL",
+            "evidence": {
+                "path": str(path),
+                "matches": fail_matches,
+                "warnings": [x for x in matches if x["kind"] == "warn"],
+            },
+        }
+    # Only WARN matches present — return PASS-with-warnings (no FAIL).
+    return {
+        "verdict": "PASS",
+        "evidence": {"warnings": matches},
+    }
+
+
 # ---------------------------------------------------------------------------
 # Dispatch + main.
 # ---------------------------------------------------------------------------
@@ -1540,6 +1656,7 @@ BINARY_ITEM_IDS: list[str] = [
     "RL-4b",
     "RL-9b",
     "AH-2b",
+    "SF-3",
 ]
 
 
@@ -1619,6 +1736,8 @@ def _run_check(
             return check_RL_9b(body, fm_raw, needs_rl9b_flag)
         if item_id == "AH-2b":
             return check_AH_2b(body)
+        if item_id == "SF-3":
+            return check_SF_3(path, body, fm, artifact_type)
         return {
             "verdict": "NA",
             "evidence": {"reason": f"runner_error: unknown item {item_id}"},

--- a/scripts/rubric_patterns.py
+++ b/scripts/rubric_patterns.py
@@ -384,6 +384,48 @@ def strip_code(text: str) -> str:
     return text
 
 
+# SF-3 Peer-Agent-Reference helpers (scoring-rubric.md §Binary-Evaluated Items).
+# strip_code_preserve_lines replaces each fenced block with an equal number of
+# newlines so that line_of_offset() in rubric_binary_evaluator.py returns the
+# same line number for any byte position outside a fence in both the raw body
+# and the stripped body. build_peer_agent_re compiles a word-boundary-safe
+# alternation pattern over a frozenset of known peer-agent names.
+
+CODE_FENCE_BACKTICK = re.compile(r"^```.*?^```", re.DOTALL | re.MULTILINE)
+CODE_FENCE_TILDE = re.compile(r"^~~~.*?^~~~", re.DOTALL | re.MULTILINE)
+
+
+def strip_code_preserve_lines(text: str) -> str:
+    """Replace fenced code blocks with newline-only blanks, preserving line numbers.
+
+    The substitution keeps exactly as many newlines as the original block
+    contained, so byte-offset-to-line-number mapping is preserved for all
+    content outside the fenced regions. Used by check_SF_3 to suppress
+    false positives from peer-agent names inside documentation code blocks.
+    """
+
+    def _to_newlines(m: re.Match) -> str:  # type: ignore[type-arg]
+        return "\n" * m.group(0).count("\n")
+
+    text = CODE_FENCE_BACKTICK.sub(_to_newlines, text)
+    text = CODE_FENCE_TILDE.sub(_to_newlines, text)
+    return text
+
+
+def build_peer_agent_re(names: frozenset) -> "re.Pattern | None":
+    """Compile a word-boundary-safe alternation regex for peer-agent name detection.
+
+    Sorts names longest-first so the alternation favours longest prefix wins,
+    preventing ``reviewer`` from matching before ``review-perspective-clarity``.
+    Uses hyphen-resistant boundary assertions (``(?<![\\w-])`` / ``(?![\\w-])``)
+    so ``pre-reviewer-mode`` does not match the ``reviewer`` token.
+    """
+    if not names:
+        return None
+    escaped = [re.escape(n) for n in sorted(names, key=len, reverse=True)]
+    return re.compile(rf"(?<![\w-])({'|'.join(escaped)})(?![\w-])")
+
+
 # WS-2b Conditional-Specificity-with-Marker (scoring-rubric.md — issue #70).
 # `If present / If absent` within 500 chars AFTER a block marker must have a
 # preceding prose predicate within 400 chars BEFORE the marker that names the
@@ -564,6 +606,10 @@ __all__ = [
     "CODE_FENCE",
     "INLINE_CODE",
     "strip_code",
+    "CODE_FENCE_BACKTICK",
+    "CODE_FENCE_TILDE",
+    "strip_code_preserve_lines",
+    "build_peer_agent_re",
     "WS_2B_BLOCK_MARKER",
     "WS_2B_IF_CLAUSE",
     "WS_2B_PROSE_PREDICATE",

--- a/skills/review-claude-config/references/agent-evaluation-guide.md
+++ b/skills/review-claude-config/references/agent-evaluation-guide.md
@@ -47,6 +47,7 @@ the `effort` Opus 4.7 compatibility table. If the parent guide overflows
 | TV-6 | Declared `hooks` reference valid event names from the 26-event catalog (`PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Stop`, etc.); event-to-CLI-version compatible with target runtime? [If `hooks` present] | Meta |
 | SF-1 | All context self-contained — no external files assumed? | CE |
 | SF-2 | Long body uses headings for structure (not dense prose)? | Clarity |
+| SF-3 | Body does not name peer agents (sibling agents/*.md `name:` fields) outside fenced code blocks. Skill-files exempt. | Meta | n/a |
 | AP-2 | No tools copied from another agent without pruning unused ones? | Safety |
 | AP-3 | `disable-model-invocation: true` present if user-only invocation is appropriate? | Meta |
 | AP-4 | Non-guardrail sections use MUST/CRITICAL ≤3 times total? | PE |

--- a/skills/review-claude-config/references/convergence-rules.yaml
+++ b/skills/review-claude-config/references/convergence-rules.yaml
@@ -43,6 +43,7 @@ DETERMINISTIC_SUBSET:
   - RL-9b
   - SAMP-1
   - SAMP-2
+  - SF-3
   - SP-2
   - SP-2b
   - SP-4

--- a/skills/review-claude-config/references/merge-rules.md
+++ b/skills/review-claude-config/references/merge-rules.md
@@ -100,6 +100,7 @@ Cap table (each row: FAIL on `item` caps `dimension` at `cap_grade`):
 | SAMP-2 | Metadata | **F** | §Sampling-Param Migration (runtime 400 on Opus 4.7) |
 | META-2 | Metadata | C | §Trigger-Consistency grade boundary |
 | META-4 | Metadata | C | §Trigger-Consistency (third-person discovery risk) |
+| SF-3 | Metadata | C | §Body-Coupling — peer-agent name leakage |
 | SP-2b / SP-4b / IJ-1b | Safety | C | §Tool-Grant Alignment grade boundary |
 | RL-1b / RL-3b / RL-4b / RL-9b | Safety | C | §Agentic Reliability Binary Items grade boundary |
 

--- a/skills/review-claude-config/references/scoring-rubric.md
+++ b/skills/review-claude-config/references/scoring-rubric.md
@@ -222,7 +222,7 @@ Grade boundary: agentic items must pass ALL 4 RL-b checks for Safety A; any one 
 
 This section is the canonical source for `BINARY_ITEM_IDS`, `NARRATIVE_PARENT_IDS`, and `ITEM_DIMENSION` consumed by `scripts/merge_findings.py`. CI regenerates `merge-policy.yaml` from these tables — never edit the yaml directly.
 
-### Binary-Evaluated Items (skill rubric, 32)
+### Binary-Evaluated Items (skill rubric, 33)
 
 These items have a deterministic PASS/FAIL/NA verdict from `scripts/rubric_binary_evaluator.py`. The `Dimension` column pins the item to a specific rubric dimension; perspective findings on these items get re-canonicalized in the merge layer (issue #70).
 
@@ -250,6 +250,7 @@ These items have a deterministic PASS/FAIL/NA verdict from `scripts/rubric_binar
 | COMP-Y | Completeness |
 | COMP-Z | Completeness |
 | AH-2b | Completeness |
+| SF-3 | Metadata |
 | SAMP-1 | Prompt Engineering |
 | PE-1 | Prompt Engineering |
 | PE-2 | Prompt Engineering |
@@ -327,6 +328,7 @@ Collisions deliberately omitted (same ID, different dimension per rubric — pin
 | Item | Dimension |
 |---|---|
 | SF-2 | Clarity |
+| SF-3 | Metadata |
 | RL-7 | Clarity |
 | DA-4 | Completeness |
 | TC-1 | Completeness |

--- a/skills/review-claude-config/references/token-budgets.json
+++ b/skills/review-claude-config/references/token-budgets.json
@@ -5,7 +5,7 @@
     "engineering-baseline.md": 4350,
     "signal-catalog.md": 1400,
     "skill-evaluation-guide.md": 1700,
-    "agent-evaluation-guide.md": 2100,
+    "agent-evaluation-guide.md": 2200,
     "claude-md-evaluation-guide.md": 800,
     "hook-evaluation-guide.md": 1500,
     "mcp-evaluation-guide.md": 1200,

--- a/skills/review-skill/references/merge-policy.yaml
+++ b/skills/review-skill/references/merge-policy.yaml
@@ -26,6 +26,7 @@ binary_item_ids:
 - COMP-Y
 - COMP-Z
 - AH-2b
+- SF-3
 - SAMP-1
 - PE-1
 - PE-2
@@ -75,6 +76,7 @@ item_dimension:
   COMP-Y: Completeness
   COMP-Z: Completeness
   AH-2b: Completeness
+  SF-3: Metadata
   SAMP-1: Prompt Engineering
   PE-1: Prompt Engineering
   PE-2: Prompt Engineering
@@ -111,6 +113,7 @@ binary_caps:
   - {item: RL-9b, dimension: Safety, cap: C}
 agent_item_dimension:
   SF-2: Clarity
+  SF-3: Metadata
   RL-7: Clarity
   DA-4: Completeness
   TC-1: Completeness

--- a/tests/eval_cases/case_09_sf3_positive_recommended_chain.yaml
+++ b/tests/eval_cases/case_09_sf3_positive_recommended_chain.yaml
@@ -1,0 +1,43 @@
+id: case-09-sf3-positive-recommended-chain
+kind: detection
+description: SF-3 Positive — agent body names peer agents in prose; binary evaluator must emit a High Metadata finding.
+target_skill: review-agent
+artifacts:
+  primary: tests/fixtures/eval/case_09_sf3_positive.md
+findings_fixture: tests/fixtures/eval/case_09_findings.json
+defects:
+  - { item: SF-3, dim: Metadata, sev: High, desc: "Peer-agent name referenced in body prose outside fenced block" }
+sprint_contract:
+  - id: C9-1
+    description: "Binary evaluator emits SF-3 FAIL finding with severity High."
+  - id: C9-2
+    description: "Finding evidence cites the matched peer-agent token and source line."
+  - id: C9-3
+    description: "Finding includes non-empty current and recommended blocks."
+expected:
+  required_findings:
+    - { item: SF-3, dim: Metadata, severity: [High] }
+  forbidden_findings: []
+  field_invariants:
+    - "every High/Medium finding has non-empty evidence"
+    - "every High/Medium finding has non-empty validation"
+    - "every High finding has non-empty current and recommended"
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-agent
+    target_arg: tests/fixtures/eval/case_09_sf3_positive.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_09_sf3_positive.md
+  reviewer_behavior: skills/review-agent/SKILL.md
+notes: |
+  AC1 coverage: body contains peer-agent names ("reviewer", "team-red") in
+  prose outside a fenced code block. Binary evaluator SF-3 check must
+  detect this and emit a High Metadata finding. The synthesised findings.json
+  carries one SF-3 binary-evaluator finding.

--- a/tests/eval_cases/case_10_sf3_negative_clean.yaml
+++ b/tests/eval_cases/case_10_sf3_negative_clean.yaml
@@ -1,0 +1,35 @@
+id: case-10-sf3-negative-clean
+kind: clean
+description: SF-3 Negative — agent body contains no peer-agent name references; SF-3 must not fire.
+target_skill: review-agent
+artifacts:
+  primary: tests/fixtures/eval/case_10_sf3_negative.md
+findings_fixture: tests/fixtures/eval/case_10_findings.json
+sprint_contract:
+  - id: C10-1
+    description: "Binary evaluator emits no SF-3 finding (PASS or NA)."
+  - id: C10-2
+    description: "No Metadata finding with checklist_item SF-3 appears in findings."
+expected:
+  required_findings: []
+  forbidden_findings:
+    - { item: SF-3, dim: Metadata }
+  field_invariants: []
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-agent
+    target_arg: tests/fixtures/eval/case_10_sf3_negative.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_10_sf3_negative.md
+  reviewer_behavior: skills/review-agent/SKILL.md
+notes: |
+  AC2 coverage: agent body uses generic role nouns ("configured review agent")
+  without naming any peer agent directly. SF-3 must return PASS (or NA if no
+  discoverable siblings). The synthesised findings.json has no findings.

--- a/tests/eval_cases/case_11_sf3_skill_exemption.yaml
+++ b/tests/eval_cases/case_11_sf3_skill_exemption.yaml
@@ -1,0 +1,36 @@
+id: case-11-sf3-skill-exemption
+kind: clean
+description: SF-3 Skill Exemption — skill artifact naming peer agents must not trigger SF-3 (agent-only scope).
+target_skill: review-skill
+artifacts:
+  primary: tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md
+findings_fixture: tests/fixtures/eval/case_11_findings.json
+sprint_contract:
+  - id: C11-1
+    description: "Binary evaluator returns SF-3 NA for skill artifact."
+  - id: C11-2
+    description: "No SF-3 finding in output — skills are orchestrators by design."
+expected:
+  required_findings: []
+  forbidden_findings:
+    - { item: SF-3, dim: Metadata }
+  field_invariants: []
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-skill
+    target_arg: tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md
+  reviewer_behavior: skills/review-skill/SKILL.md
+notes: |
+  AC3 coverage: skill artifact references peer-agent names ("reviewer",
+  "team-red") in its body prose. SF-3 is agent-only scope — skills are
+  orchestrators by design and therefore exempt. Binary evaluator must
+  return SF-3 NA, not FAIL. No SF-3 finding in synthesised findings.json.

--- a/tests/eval_cases/case_12_sf3_fp_scaffold_template.yaml
+++ b/tests/eval_cases/case_12_sf3_fp_scaffold_template.yaml
@@ -1,0 +1,36 @@
+id: case-12-sf3-fp-scaffold-template
+kind: clean
+description: SF-3 FP Scaffold Template — peer-agent name in frontmatter example block must not trigger SF-3 (split_content excludes frontmatter).
+target_skill: review-agent
+artifacts:
+  primary: tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md
+findings_fixture: tests/fixtures/eval/case_12_findings.json
+sprint_contract:
+  - id: C12-1
+    description: "SF-3 returns PASS — peer name in frontmatter description is excluded by split_content."
+  - id: C12-2
+    description: "No SF-3 finding in output."
+expected:
+  required_findings: []
+  forbidden_findings:
+    - { item: SF-3, dim: Metadata }
+  field_invariants: []
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-agent
+    target_arg: tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md
+  reviewer_behavior: skills/review-agent/SKILL.md
+notes: |
+  AC4a coverage: the artifact's body does not reference any peer-agent name
+  in prose. The frontmatter description mentions "pr-reviewer" as a template
+  example, but split_content() returns only the body — so SF-3 never scans
+  the frontmatter. No SF-3 finding expected.

--- a/tests/eval_cases/case_13_sf3_fp_human_role.yaml
+++ b/tests/eval_cases/case_13_sf3_fp_human_role.yaml
@@ -1,0 +1,36 @@
+id: case-13-sf3-fp-human-role
+kind: clean
+description: SF-3 FP Human Role — bare "reviewer" as a human role noun (no .md in 30 chars) must produce PASS-with-warning, not FAIL.
+target_skill: review-agent
+artifacts:
+  primary: tests/fixtures/eval/case_13_sf3_fp_human_role.md
+findings_fixture: tests/fixtures/eval/case_13_findings.json
+sprint_contract:
+  - id: C13-1
+    description: "SF-3 returns PASS (not FAIL) when body uses 'reviewer' as human role noun without .md suffix."
+  - id: C13-2
+    description: "No High SF-3 finding in output; at most a warning annotation."
+expected:
+  required_findings: []
+  forbidden_findings:
+    - { item: SF-3, dim: Metadata }
+  field_invariants: []
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-agent
+    target_arg: tests/fixtures/eval/case_13_sf3_fp_human_role.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_13_fp_human_role.md
+  reviewer_behavior: skills/review-agent/SKILL.md
+notes: |
+  AC4b coverage: body uses "reviewer" as a human role noun ("ask the reviewer
+  to confirm"). The disambiguation rule: when matched token is "reviewer" AND
+  no ".md" appears within 30 chars after the match end, emit WARN (not FAIL)
+  and return PASS. No SF-3 FAIL finding expected.

--- a/tests/eval_cases/case_14_sf3_fp_fenced_block.yaml
+++ b/tests/eval_cases/case_14_sf3_fp_fenced_block.yaml
@@ -1,0 +1,36 @@
+id: case-14-sf3-fp-fenced-block
+kind: clean
+description: SF-3 FP Fenced Block — peer-agent names appearing only inside a fenced code block must not trigger SF-3.
+target_skill: review-agent
+artifacts:
+  primary: tests/fixtures/eval/case_14_sf3_fp_fenced_block.md
+findings_fixture: tests/fixtures/eval/case_14_findings.json
+sprint_contract:
+  - id: C14-1
+    description: "SF-3 returns PASS when peer name appears only inside a fenced code block."
+  - id: C14-2
+    description: "No SF-3 finding in output — fenced references are legitimate documentation."
+expected:
+  required_findings: []
+  forbidden_findings:
+    - { item: SF-3, dim: Metadata }
+  field_invariants: []
+acceptance:
+  precision: ">= 1.0"
+  recall:    ">= 1.0"
+execution:
+  dispatch:
+    command: /review-agent
+    target_arg: tests/fixtures/eval/case_14_sf3_fp_fenced_block.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_14_sfp_fenced_block.md
+  reviewer_behavior: skills/review-agent/SKILL.md
+notes: |
+  AC4c coverage: peer-agent names ("reviewer", "team-red") appear only inside
+  a fenced code block. strip_code_preserve_lines() replaces the block with
+  blank lines before scanning, so the names are not visible to the pattern.
+  SF-3 must return PASS. No SF-3 finding in synthesised findings.json.

--- a/tests/fixtures/eval/case_09_findings.json
+++ b/tests/fixtures/eval/case_09_findings.json
@@ -1,0 +1,26 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-09-sf3-positive",
+  "artifact_path": "tests/fixtures/eval/case_09_sf3_positive.md",
+  "artifact_type": "agent",
+  "findings": [
+    {
+      "id": "SF-3:tests/fixtures/eval/case_09_sf3_positive.md:Metadata/v1",
+      "checklist_item": "SF-3",
+      "dimension": "Metadata",
+      "severity": "High",
+      "evidence": "line 12; matched_token='reviewer' — peer-agent name referenced in body prose outside fenced code block",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/eval/case_09_sf3_positive.md",
+      "line_range": "12",
+      "why": "Binary rubric item SF-3 FAIL — agent body names sibling agent 'reviewer' in prose outside a fenced block. This creates implicit peer coupling that breaks skill self-containment and degrades description-based routing.",
+      "validation": "Re-run scripts/rubric_binary_evaluator.py on the artifact and confirm SF-3 verdict PASS after removing or fencing the peer-agent name reference.",
+      "current": "Dispatch reviewer for a second-pass review of all High findings.",
+      "recommended": "Remove the peer-agent name reference from body prose. Use a generic role noun ('the review agent', 'the secondary reviewer') or move the reference into a fenced code block if documenting a specific workflow.",
+      "perspective": "binary-evaluator"
+    }
+  ]
+}

--- a/tests/fixtures/eval/case_09_sf3_positive.md
+++ b/tests/fixtures/eval/case_09_sf3_positive.md
@@ -1,0 +1,13 @@
+---
+name: sf3-positive-agent
+description: Orchestrates analysis then dispatches peers. Not for standalone use.
+---
+
+## Analysis Phase
+
+Perform the primary analysis of the target artifact.
+
+## Recommended review chain
+
+Dispatch reviewer for a second-pass review of all High findings.
+Then dispatch team-red for adversarial security analysis.

--- a/tests/fixtures/eval/case_10_findings.json
+++ b/tests/fixtures/eval/case_10_findings.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-10-sf3-negative",
+  "artifact_path": "tests/fixtures/eval/case_10_sf3_negative.md",
+  "artifact_type": "agent",
+  "findings": []
+}

--- a/tests/fixtures/eval/case_10_sf3_negative.md
+++ b/tests/fixtures/eval/case_10_sf3_negative.md
@@ -1,0 +1,13 @@
+---
+name: sf3-clean-agent
+description: Orchestrates analysis without naming peer agents. Not for standalone use.
+---
+
+## Analysis Phase
+
+Perform the primary analysis of the target artifact.
+
+## Review Phase
+
+After the primary analysis is complete, request a secondary review from the
+configured review agent. No peer-agent names are referenced directly in this body.

--- a/tests/fixtures/eval/case_11_findings.json
+++ b/tests/fixtures/eval/case_11_findings.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-11-sf3-skill-exemption",
+  "artifact_path": "tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md",
+  "artifact_type": "skill",
+  "findings": []
+}

--- a/tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md
+++ b/tests/fixtures/eval/case_11_sf3_skill_exemption.SKILL.md
@@ -1,0 +1,14 @@
+---
+name: sf3-skill-exemption-skill
+description: Reviews configuration. Not for agents or rules.
+allowed-tools:
+  - Read
+  - Glob
+---
+
+## Instructions
+
+This skill orchestrates peer agents by design. It may reference agent names
+including reviewer and team-red as part of its orchestration workflow.
+
+Skills are exempt from SF-3 because they are orchestrators, not peers.

--- a/tests/fixtures/eval/case_12_findings.json
+++ b/tests/fixtures/eval/case_12_findings.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-12-sf3-fp-scaffold-template",
+  "artifact_path": "tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md",
+  "artifact_type": "agent",
+  "findings": []
+}

--- a/tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md
+++ b/tests/fixtures/eval/case_12_sf3_fp_scaffold_template.md
@@ -1,0 +1,11 @@
+---
+name: sf3-scaffold-template-agent
+description: Scaffolds analysis workflows. Not for direct peer-dispatch.
+---
+
+## Instructions
+
+Scaffold an analysis workflow based on the provided template.
+
+The template may include frontmatter like `name: pr-reviewer` as an example,
+but the body does not reference any peer agent by name in its prose.

--- a/tests/fixtures/eval/case_13_findings.json
+++ b/tests/fixtures/eval/case_13_findings.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-13-sf3-fp-human-role",
+  "artifact_path": "tests/fixtures/eval/case_13_sf3_fp_human_role.md",
+  "artifact_type": "agent",
+  "findings": []
+}

--- a/tests/fixtures/eval/case_13_sf3_fp_human_role.md
+++ b/tests/fixtures/eval/case_13_sf3_fp_human_role.md
@@ -1,0 +1,11 @@
+---
+name: sf3-human-role-agent
+description: Orchestrates review workflow without naming peer agents. Not for standalone use.
+---
+
+## Instructions
+
+Perform the analysis and then ask the reviewer to confirm the output.
+The reviewer's role is to validate findings before they are delivered.
+
+This body uses "reviewer" as a human role noun, not as a peer-agent reference.

--- a/tests/fixtures/eval/case_14_findings.json
+++ b/tests/fixtures/eval/case_14_findings.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-14-sf3-fp-fenced-block",
+  "artifact_path": "tests/fixtures/eval/case_14_sf3_fp_fenced_block.md",
+  "artifact_type": "agent",
+  "findings": []
+}

--- a/tests/fixtures/eval/case_14_sf3_fp_fenced_block.md
+++ b/tests/fixtures/eval/case_14_sf3_fp_fenced_block.md
@@ -1,0 +1,16 @@
+---
+name: sf3-fenced-block-agent
+description: Documents peer-dispatch pattern in fenced blocks. Not for standalone use.
+---
+
+## Instructions
+
+Perform the analysis. The following shows an example workflow — do not execute it directly:
+
+```
+reviewer → primary analysis
+team-red → adversarial check
+```
+
+The peer-agent names above appear only inside a fenced code block
+and must not trigger SF-3.

--- a/tests/test_merge_findings.py
+++ b/tests/test_merge_findings.py
@@ -1397,11 +1397,11 @@ class TestLazyLoadPolicy:
         """Sanity: lazy-loaded values match the YAML committed in the repo."""
         import merge_findings
 
-        assert len(merge_findings.BINARY_ITEM_IDS) == 32
+        assert len(merge_findings.BINARY_ITEM_IDS) == 33
         assert len(merge_findings.NARRATIVE_PARENT_IDS) == 15
-        assert len(merge_findings.ITEM_DIMENSION) == 33
+        assert len(merge_findings.ITEM_DIMENSION) == 34
         assert len(merge_findings.BINARY_CAPS) == 22
-        assert len(merge_findings.AGENT_ITEM_DIMENSION) == 35
+        assert len(merge_findings.AGENT_ITEM_DIMENSION) == 36
         # Shape preservation — frozenset of strings, list-of-3-tuples.
         assert isinstance(merge_findings.BINARY_ITEM_IDS, frozenset)
         assert isinstance(merge_findings.NARRATIVE_PARENT_IDS, frozenset)

--- a/tests/test_regenerate_merge_policy.py
+++ b/tests/test_regenerate_merge_policy.py
@@ -14,11 +14,11 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import regenerate_merge_policy as rmp  # noqa: E402
 
 EXPECTED = {
-    "binary_item_ids": 32,
+    "binary_item_ids": 33,
     "narrative_parent_ids": 15,
-    "item_dimension": 33,
+    "item_dimension": 34,
     "binary_caps": 22,
-    "agent_item_dimension": 35,
+    "agent_item_dimension": 36,
 }
 
 TOP_KEYS = (

--- a/tests/test_rubric_binary_evaluator.py
+++ b/tests/test_rubric_binary_evaluator.py
@@ -34,6 +34,9 @@ from rubric_binary_evaluator import (  # noqa: E402
     SCHEMA_VERSION,
     check_AH_2b,
     check_CE_X,
+    check_SF_3,
+    discover_peer_agent_names,
+    split_content,
     check_CLAR_1,
     check_CLAR_2,
     check_CLAR_3,
@@ -1400,10 +1403,10 @@ class TestSchemaStability:
             assert "evidence" in v, f"{item_id} missing evidence"
             assert isinstance(v["evidence"], dict)
 
-    def test_stats_counts_sum_to_32(self):
+    def test_stats_counts_sum_to_33(self):
         result = evaluate(REVIEW_SKILL_FIXTURE)
         s = result["stats"]
-        assert s["pass"] + s["fail"] + s["na"] == 32
+        assert s["pass"] + s["fail"] + s["na"] == 33
 
 
 REVIEW_SKILL_EXPECTED = {
@@ -1439,6 +1442,7 @@ REVIEW_SKILL_EXPECTED = {
     "RL-4b": "PASS",
     "RL-9b": "PASS",
     "AH-2b": "PASS",
+    "SF-3": "NA",  # skill artifact — SF-3 agent-only scope
 }
 
 REVIEW_PERSPECTIVE_CLARITY_AGENT_EXPECTED = {
@@ -1474,6 +1478,7 @@ REVIEW_PERSPECTIVE_CLARITY_AGENT_EXPECTED = {
     "RL-4b": "FAIL",
     "RL-9b": "NA",
     "AH-2b": "NA",
+    "SF-3": "NA",  # no sibling agents discoverable (single agent in fixture dir after self-exclusion)
 }
 
 SCAFFOLD_SKILL_EXPECTED = {
@@ -1509,6 +1514,7 @@ SCAFFOLD_SKILL_EXPECTED = {
     "RL-4b": "PASS",
     "RL-9b": "FAIL",
     "AH-2b": "NA",
+    "SF-3": "NA",  # skill artifact — SF-3 agent-only scope
 }
 
 
@@ -1529,7 +1535,7 @@ class TestEndToEndFixtures:
         assert fixture.exists(), f"fixture missing: {fixture}"
         result = evaluate(fixture)
         assert result["stats"]["runner_error"] == 0
-        assert result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"] == 32
+        assert result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"] == 33
         actual = {k: v["verdict"] for k, v in result["verdicts"].items()}
         assert actual == expected
 
@@ -1565,21 +1571,21 @@ class TestRepoWideSmokeStrict:
         result = evaluate(path)
         assert result["stats"]["runner_error"] == 0
         total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-        assert total == 32
+        assert total == 33
 
 
 class TestRepoWideSmokeLenient:
-    """Every skills/*/SKILL.md evaluator invocation returns 32 verdicts;
+    """Every skills/*/SKILL.md evaluator invocation returns 33 verdicts;
     runner_error per skill is logged but not asserted."""
 
-    def test_all_skills_produce_32_verdicts(self):
+    def test_all_skills_produce_33_verdicts(self):
         skills = sorted((REPO_ROOT / "skills").glob("*/SKILL.md"))
         assert len(skills) >= 10, "expected multiple skill targets"
         errors: list[tuple[str, int]] = []
         for p in skills:
             result = evaluate(p)
             total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-            assert total == 32, f"{p}: total {total} != 32"
+            assert total == 33, f"{p}: total {total} != 33"
             if result["stats"]["runner_error"]:
                 errors.append((str(p), result["stats"]["runner_error"]))
         # Surface drift without failing the suite: errors are reported
@@ -1625,9 +1631,9 @@ class TestRunnerErrorHandling:
         p.write_text("", encoding="utf-8")
         result = evaluate(p)
         assert result["stats"]["runner_error"] == 0
-        # All 32 items produce verdicts (mostly NA/FAIL for missing content).
+        # All 33 items produce verdicts (mostly NA/FAIL for missing content).
         total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-        assert total == 32
+        assert total == 33
 
     def test_no_frontmatter_no_crash(self, tmp_path):
         p = tmp_path / "body-only.md"
@@ -1695,3 +1701,362 @@ class TestToolsList:
 
     def test_empty_string(self):
         assert tools_list({"allowed-tools": ""}) == []
+
+
+# ---------------------------------------------------------------------------
+# SF-3 — peer-agent name body-cross-reference check.
+# ---------------------------------------------------------------------------
+
+
+def _write_agent(directory: pathlib.Path, stem: str, name: str, body: str) -> pathlib.Path:
+    """Write a minimal agent fixture file into an agents/ subdirectory."""
+    agents_dir = directory / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    p = agents_dir / f"{stem}.md"
+    p.write_text(
+        f"---\nname: {name}\ndescription: Test agent. Not for other uses.\n---\n{body}",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestCheckSF3:
+    # ------------------------------------------------------------------
+    # AC2: clean agent → PASS
+    # ------------------------------------------------------------------
+    def test_clean_agent_passes(self, tmp_path):
+        peer = _write_agent(tmp_path, "sibling-agent", "sibling-agent", "body without mentions")
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", "This does useful work.")
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "PASS"
+
+    # ------------------------------------------------------------------
+    # AC1: body with two peer-name hits → FAIL with file-absolute lines
+    # ------------------------------------------------------------------
+    def test_recommended_review_chain_block_fails(self, tmp_path):
+        peer1 = _write_agent(tmp_path, "reviewer", "reviewer", "body")
+        peer2 = _write_agent(tmp_path, "team-red", "team-red", "body")
+        body_text = (
+            "## Recommended review chain\n"
+            "Dispatch reviewer for analysis.\n"
+            "Dispatch team-red for adversarial check.\n"
+        )
+        subject = _write_agent(
+            tmp_path, "subject-agent", "subject-agent", body_text
+        )
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        assert len(matches) >= 1
+        # Lines must be file-absolute (include frontmatter offset = 4 lines).
+        for m in matches:
+            assert m["line"] >= 4, f"line {m['line']} not file-absolute (frontmatter = 4 lines)"
+
+    # ------------------------------------------------------------------
+    # AC3: skill artifact → NA
+    # ------------------------------------------------------------------
+    def test_skill_artifact_returns_na(self, tmp_path):
+        # Skills live in skills/<name>/SKILL.md — classify_artifact returns "skill".
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        p = skill_dir / "SKILL.md"
+        p.write_text("---\nname: my-skill\ndescription: Test skill. Not for agents.\n---\nbody", encoding="utf-8")
+        fm, _ = parse_frontmatter(p)
+        _, body = split_content(p)
+        result = check_SF_3(p, body, fm, artifact_type="skill")
+        assert result["verdict"] == "NA"
+        assert "agent" in result["evidence"]["reason"].lower()
+
+    # ------------------------------------------------------------------
+    # AC4c: peer name only inside fenced ``` block → PASS
+    # ------------------------------------------------------------------
+    def test_inside_fenced_block_skipped(self, tmp_path):
+        peer = _write_agent(tmp_path, "peer-agent", "peer-agent", "body")
+        body_text = "Before fence.\n```\npeer-agent is mentioned here\n```\nAfter fence.\n"
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "PASS"
+
+    def test_inside_tilde_fenced_block_skipped(self, tmp_path):
+        peer = _write_agent(tmp_path, "peer-agent", "peer-agent", "body")
+        body_text = "Before fence.\n~~~\npeer-agent is mentioned here\n~~~\nAfter fence.\n"
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "PASS"
+
+    # ------------------------------------------------------------------
+    # AC4b: bare "reviewer" (no .md in next 30 chars) → PASS-with-warnings
+    # ------------------------------------------------------------------
+    def test_bare_reviewer_word_warns_not_fails(self, tmp_path):
+        _write_agent(tmp_path, "reviewer", "reviewer", "body")
+        body_text = "Ask the reviewer to check the output.\n"
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        # PASS-with-warnings: no FAIL matches.
+        assert result["verdict"] == "PASS"
+        warnings = result["evidence"].get("warnings", [])
+        assert len(warnings) >= 1
+        assert warnings[0]["reason"] == "human-role-disambiguation-needed"
+
+    # ------------------------------------------------------------------
+    # "reviewer.md" (`.md` within 30 chars) → FAIL (peer-file reference)
+    # ------------------------------------------------------------------
+    def test_reviewer_with_md_suffix_fails(self, tmp_path):
+        _write_agent(tmp_path, "reviewer", "reviewer", "body")
+        body_text = "See reviewer.md for details.\n"
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+
+    # ------------------------------------------------------------------
+    # Self-name not matched (subtract own name from peer set).
+    # ------------------------------------------------------------------
+    def test_self_name_not_matched(self, tmp_path):
+        # subject is named "reviewer"; body contains "reviewer" — should PASS (self-skip).
+        _write_agent(tmp_path, "sibling", "sibling", "body")
+        body_text = "The reviewer evaluates the input.\n"
+        subject = _write_agent(tmp_path, "reviewer", "reviewer", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        # "reviewer" is own name — excluded from peer set → PASS.
+        assert result["verdict"] == "PASS"
+
+    # ------------------------------------------------------------------
+    # NA when no sibling agents discoverable (evaluator level).
+    # ------------------------------------------------------------------
+    def test_no_sibling_agents_returns_na(self, tmp_path):
+        # Single agent, no siblings after self-exclusion.
+        subject = _write_agent(tmp_path, "lonely-agent", "lonely-agent", "body with lonely-agent mention")
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "NA"
+        assert "no sibling agents" in result["evidence"]["reason"].lower()
+
+    # ------------------------------------------------------------------
+    # 30-char window boundary test (AC4b edge).
+    # ------------------------------------------------------------------
+    def test_30_char_window_boundary(self, tmp_path):
+        _write_agent(tmp_path, "reviewer", "reviewer", "body")
+        _write_agent(tmp_path, "sibling", "sibling", "body")
+
+        # ".md" within the 30-char window from m.end() → FAIL.
+        # Use "see reviewer " prefix so the word boundary lookahead passes
+        # (the character after "reviewer" is a space, not \w or -).
+        # After match, m.end() points past "reviewer". The 30-char window is
+        # stripped[m.end():m.end()+30]. With " " + "x"*26 + ".md" after
+        # "reviewer", the window = " x...x.md" (30 chars); ".md" starts at
+        # index 27 (positions 0..29 inclusive) → inside window → FAIL.
+        in_window_body = "see reviewer " + "x" * 26 + ".md"
+        subject_in = _write_agent(tmp_path, "subject-in", "subject-in", in_window_body)
+        fm_in, _ = parse_frontmatter(subject_in)
+        _, body_in = split_content(subject_in)
+        result_in = check_SF_3(subject_in, body_in, fm_in, artifact_type="agent")
+        assert result_in["verdict"] == "FAIL", "'.md' at index 27 of window (in 30-char window) should FAIL"
+
+        # ".md" exactly at offset 30 from m.end() (excluded from window) → WARN.
+        # window ends at m.end()+30 exclusive; ".md" starts at m.end()+30 → excluded.
+        out_window_body = "see reviewer " + "x" * 30 + ".md"
+        subject_out = _write_agent(tmp_path, "subject-out", "subject-out", out_window_body)
+        fm_out, _ = parse_frontmatter(subject_out)
+        _, body_out = split_content(subject_out)
+        result_out = check_SF_3(subject_out, body_out, fm_out, artifact_type="agent")
+        assert result_out["verdict"] == "PASS", "'.md' at offset 30 (outside window) should WARN/PASS"
+
+    # ------------------------------------------------------------------
+    # Frontmatter match skipped (split_content removes frontmatter).
+    # ------------------------------------------------------------------
+    def test_frontmatter_match_skipped_at_evaluator_level(self, tmp_path):
+        # A sibling named "pr-reviewer" appears in a frontmatter <example> block.
+        # split_content returns only the body, so frontmatter-only matches → no FAIL.
+        _write_agent(tmp_path, "pr-reviewer", "pr-reviewer", "body")
+        # The subject has "pr-reviewer" only in the frontmatter description.
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        p = agents_dir / "subject-agent.md"
+        p.write_text(
+            "---\nname: subject-agent\ndescription: Not pr-reviewer related.\n---\n"
+            "This body has no peer names.\n",
+            encoding="utf-8",
+        )
+        fm, _ = parse_frontmatter(p)
+        _, body = split_content(p)
+        result = check_SF_3(p, body, fm, artifact_type="agent")
+        assert result["verdict"] == "PASS"
+
+    # ------------------------------------------------------------------
+    # Mixed long + short name: FAIL for long + WARN for bare "reviewer".
+    # ------------------------------------------------------------------
+    def test_mixed_long_and_short_names_in_body(self, tmp_path):
+        _write_agent(tmp_path, "review-perspective-clarity", "review-perspective-clarity", "body")
+        _write_agent(tmp_path, "reviewer", "reviewer", "body")
+        body_text = (
+            "Dispatch review-perspective-clarity first.\n"
+            "Ask the reviewer to verify.\n"
+        )
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        warnings = result["evidence"].get("warnings", [])
+        assert len(matches) >= 1, "review-perspective-clarity should be a FAIL match"
+        assert len(warnings) >= 1, "bare reviewer should be a WARN"
+
+    # ------------------------------------------------------------------
+    # Line numbers correct after fenced block (F2 fix pin).
+    # ------------------------------------------------------------------
+    def test_line_numbers_correct_after_fenced_block(self, tmp_path):
+        peer = _write_agent(tmp_path, "peer-agent", "peer-agent", "body")
+        # 4-line frontmatter (---\nname\ndescription\n---) + body:
+        # body line 1: blank
+        # body lines 2-4: fenced block
+        # body line 5: peer-agent mention  ← expected file-absolute line = 4 + 5 = 9
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        p = agents_dir / "subject-agent.md"
+        p.write_text(
+            "---\nname: subject-agent\ndescription: Test. Not for production.\n---\n"
+            "\n```\nsome code\n```\npeer-agent is here\n",
+            encoding="utf-8",
+        )
+        fm, _ = parse_frontmatter(p)
+        _, body = split_content(p)
+        # Count actual frontmatter lines.
+        full_text = p.read_text(encoding="utf-8")
+        fm_line_count = full_text.count("\n") - body.count("\n")
+        result = check_SF_3(p, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        assert len(matches) == 1
+        reported_line = matches[0]["line"]
+        # Body line of "peer-agent is here" = 5 (1 blank + 3 fence lines + 1 match).
+        expected_abs_line = fm_line_count + 5
+        assert reported_line == expected_abs_line, (
+            f"Expected file-absolute line {expected_abs_line}, got {reported_line}"
+        )
+
+    # ------------------------------------------------------------------
+    # Paired inside + outside fence: exactly 1 FAIL (outside) (team-red R2 §3).
+    # ------------------------------------------------------------------
+    def test_paired_inside_and_outside_fence(self, tmp_path):
+        peer = _write_agent(tmp_path, "peer-agent", "peer-agent", "body")
+        _write_agent(tmp_path, "sibling-b", "sibling-b", "body")
+        body_text = (
+            "```\npeer-agent inside fence\n```\n"
+            "peer-agent outside fence\n"
+        )
+        subject = _write_agent(tmp_path, "subject-agent", "subject-agent", body_text)
+        fm, _ = parse_frontmatter(subject)
+        _, body = split_content(subject)
+        result = check_SF_3(subject, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        assert len(matches) == 1
+        # The outside-fence match is on the 4th body line.
+        full_text = subject.read_text(encoding="utf-8")
+        fm_line_count = full_text.count("\n") - body.count("\n")
+        assert matches[0]["line"] == fm_line_count + 4
+
+    # ------------------------------------------------------------------
+    # Un-FM agent: frontmatter_line_count == 0 → body-relative lines (F5).
+    # ------------------------------------------------------------------
+    def test_un_frontmatter_agent_line_numbers_body_relative(self, tmp_path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        # Sibling with no frontmatter.
+        sib = agents_dir / "peer-agent.md"
+        sib.write_text("no frontmatter\n", encoding="utf-8")
+        # Subject with no frontmatter.
+        p = agents_dir / "subject-agent.md"
+        p.write_text("line1\nline2\npeer-agent here\n", encoding="utf-8")
+        fm, _ = parse_frontmatter(p)
+        _, body = split_content(p)
+        result = check_SF_3(p, body, fm, artifact_type="agent")
+        # Sibling name = "peer-agent" (stem fallback since no FM).
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        # line 3 body-relative (no frontmatter offset).
+        assert matches[0]["line"] == 3
+
+    # ------------------------------------------------------------------
+    # Frontmatter line count accurate (6-line FM + match on body line 3 → abs 9). (F1)
+    # ------------------------------------------------------------------
+    def test_frontmatter_line_count_accurate(self, tmp_path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        sib = agents_dir / "peer-agent.md"
+        sib.write_text("---\nname: peer-agent\n---\nbody\n", encoding="utf-8")
+        p = agents_dir / "subject-agent.md"
+        # 6-line frontmatter: --- / name / description / extra1 / extra2 / ---
+        p.write_text(
+            "---\nname: subject-agent\ndescription: Test. Not for production.\nextra1: a\nextra2: b\n---\n"
+            "line1\nline2\npeer-agent here\n",
+            encoding="utf-8",
+        )
+        fm, _ = parse_frontmatter(p)
+        _, body = split_content(p)
+        full_text = p.read_text(encoding="utf-8")
+        fm_line_count = full_text.count("\n") - body.count("\n")
+        assert fm_line_count == 6, f"expected 6 FM lines, got {fm_line_count}"
+        result = check_SF_3(p, body, fm, artifact_type="agent")
+        assert result["verdict"] == "FAIL"
+        matches = result["evidence"]["matches"]
+        # Body line 3 → file-absolute line 9 (6 + 3).
+        assert matches[0]["line"] == 9
+
+    # ------------------------------------------------------------------
+    # Discovery boundary lengths: 2 (excluded), 3 (included), 64 (included), 65 (excluded). (F4)
+    # ------------------------------------------------------------------
+    def test_discovery_boundary_lengths(self, tmp_path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        subject_p = agents_dir / "subject.md"
+        subject_p.write_text("---\nname: subject\n---\nbody\n", encoding="utf-8")
+        for stem, name in [
+            ("two-ch", "ab"),                # len=2 → excluded
+            ("three", "abc"),                # len=3 → included
+            ("sixtyfour", "x" * 64),         # len=64 → included
+            ("sixtyfive", "x" * 65),         # len=65 → excluded
+        ]:
+            (agents_dir / f"{stem}.md").write_text(
+                f"---\nname: {name}\n---\nbody\n", encoding="utf-8"
+            )
+        fm, _ = parse_frontmatter(subject_p)
+        names = discover_peer_agent_names(subject_p)
+        assert "ab" not in names
+        assert "abc" in names
+        assert "x" * 64 in names
+        assert "x" * 65 not in names
+
+    # ------------------------------------------------------------------
+    # Discovery capped at 50 when 51 siblings present. (F4)
+    # ------------------------------------------------------------------
+    def test_discovery_capped_at_50_exactly(self, tmp_path):
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        subject_p = agents_dir / "subject.md"
+        subject_p.write_text("---\nname: subject\n---\nbody\n", encoding="utf-8")
+        # Create 51 siblings with 3-char names (all valid, sorted alpha).
+        for i in range(51):
+            name = f"s{i:02d}"
+            (agents_dir / f"sibling-{i:02d}.md").write_text(
+                f"---\nname: {name}\n---\nbody\n", encoding="utf-8"
+            )
+        fm, _ = parse_frontmatter(subject_p)
+        names = discover_peer_agent_names(subject_p)
+        assert len(names) == 50

--- a/tests/test_rubric_pattern_behavior.py
+++ b/tests/test_rubric_pattern_behavior.py
@@ -27,6 +27,8 @@ from rubric_patterns import (  # noqa: E402
     SECOND_PERSON,
     TERMINATION_PREDICATE,
     _inside_hitl_cycle,
+    build_peer_agent_re,
+    strip_code_preserve_lines,
 )
 
 
@@ -378,3 +380,159 @@ class TestInsideHitlCycle:
         body = 'On "Adjust": confirm.\n   \nregenerate the index.'
         offset = body.index("regenerate")
         assert _inside_hitl_cycle(body, offset) is False
+
+
+# ---------------------------------------------------------------------------
+# SF-3 helpers: strip_code_preserve_lines + build_peer_agent_re.
+# ---------------------------------------------------------------------------
+
+
+class TestSF3PeerAgentPattern:
+    """Behavioral tests for SF-3 pattern helpers.
+
+    Source of truth: scoring-rubric.md §SF-3 (Binary-Evaluated Items) +
+    rubric_patterns.py ``strip_code_preserve_lines`` / ``build_peer_agent_re``.
+    """
+
+    # ----------------------------------------------------------------
+    # Dynamic discovery finds sibling agents.
+    # ----------------------------------------------------------------
+    def test_dynamic_discovery_finds_sibling_agents(self, tmp_path):
+        """Three sibling agents → frozenset has 3 names (excluding self)."""
+        import pathlib
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        from rubric_binary_evaluator import discover_peer_agent_names, parse_frontmatter
+
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        subject = agents_dir / "subject.md"
+        subject.write_text("---\nname: subject\n---\nbody\n", encoding="utf-8")
+        for name in ("alpha", "beta", "gamma"):
+            (agents_dir / f"{name}.md").write_text(
+                f"---\nname: {name}\n---\nbody\n", encoding="utf-8"
+            )
+        names = discover_peer_agent_names(subject)
+        assert names == frozenset({"alpha", "beta", "gamma"})
+
+    # ----------------------------------------------------------------
+    # Self name excluded from peer set.
+    # ----------------------------------------------------------------
+    def test_self_name_excluded(self, tmp_path):
+        """Own `name:` not in discovery output (but sibling is)."""
+        import pathlib
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        from rubric_binary_evaluator import discover_peer_agent_names
+
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        subject = agents_dir / "me.md"
+        subject.write_text("---\nname: me\n---\nbody\n", encoding="utf-8")
+        (agents_dir / "other.md").write_text("---\nname: other\n---\nbody\n", encoding="utf-8")
+        names = discover_peer_agent_names(subject)
+        assert "me" not in names
+        assert "other" in names
+
+    # ----------------------------------------------------------------
+    # Long names take precedence over short in alternation.
+    # ----------------------------------------------------------------
+    def test_long_names_take_precedence_over_short(self):
+        """Regex sorts longest-first so `review-perspective-clarity` matches
+        before `reviewer` in a body containing both tokens.
+        """
+        names = frozenset({"review-perspective-clarity", "reviewer"})
+        pattern = build_peer_agent_re(names)
+        assert pattern is not None
+        body = "Dispatch review-perspective-clarity for analysis, then reviewer."
+        m = pattern.search(body)
+        assert m is not None
+        assert m.group(0) == "review-perspective-clarity"
+
+    # ----------------------------------------------------------------
+    # Hyphen boundary excludes mid-word match.
+    # ----------------------------------------------------------------
+    def test_hyphen_boundary_excludes_in_word_match(self):
+        """'pre-reviewer-mode' must NOT match 'reviewer'."""
+        names = frozenset({"reviewer"})
+        pattern = build_peer_agent_re(names)
+        assert pattern is not None
+        assert pattern.search("pre-reviewer-mode") is None
+
+    # ----------------------------------------------------------------
+    # strip_code_preserve_lines: line offsets preserved across fence.
+    # ----------------------------------------------------------------
+    def test_strip_code_preserve_lines_keeps_offsets(self):
+        """Content outside fence has the same line number in raw and stripped."""
+        raw = "line1\n```python\ncode\n```\nline5\n"
+        stripped = strip_code_preserve_lines(raw)
+        # "line5" must be at line 5 in both.
+        raw_line = raw[: raw.index("line5")].count("\n") + 1
+        stripped_line = stripped[: stripped.index("line5")].count("\n") + 1
+        assert raw_line == stripped_line == 5
+
+    # ----------------------------------------------------------------
+    # strip_code_preserve_lines: tilde fence.
+    # ----------------------------------------------------------------
+    def test_strip_code_preserve_lines_handles_tilde_fence(self):
+        """~~~ fenced block is stripped equivalently to ``` block."""
+        raw = "before\n~~~\ncode\n~~~\nafter\n"
+        stripped = strip_code_preserve_lines(raw)
+        raw_line_after = raw[: raw.index("after")].count("\n") + 1
+        stripped_line_after = stripped[: stripped.index("after")].count("\n") + 1
+        assert raw_line_after == stripped_line_after
+
+    # ----------------------------------------------------------------
+    # Unclosed fence does not cascade-skip remaining content.
+    # ----------------------------------------------------------------
+    def test_unclosed_fence_does_not_cascade_skip(self):
+        """Body with unbalanced opening fence (no closing ```).
+        DOTALL+MULTILINE requires a matching closing token.
+        Content after the unclosed fence remains in the stripped output.
+        """
+        raw = "before\n```\ncode without close\nafter\n"
+        stripped = strip_code_preserve_lines(raw)
+        # No match → stripped == raw (nothing removed).
+        assert "after" in stripped
+
+    # ----------------------------------------------------------------
+    # Discovery skips names shorter than 3 or longer than 64.
+    # ----------------------------------------------------------------
+    def test_discovery_skips_short_and_long_names(self, tmp_path):
+        """Name len=1 → excluded; len=3 → included; len=65 → excluded."""
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        from rubric_binary_evaluator import discover_peer_agent_names
+
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        subject = agents_dir / "subject.md"
+        subject.write_text("---\nname: subject\n---\nbody\n", encoding="utf-8")
+        (agents_dir / "short.md").write_text("---\nname: a\n---\nbody\n", encoding="utf-8")
+        (agents_dir / "ok.md").write_text("---\nname: abc\n---\nbody\n", encoding="utf-8")
+        (agents_dir / "toolong.md").write_text(
+            f"---\nname: {'x' * 65}\n---\nbody\n", encoding="utf-8"
+        )
+        names = discover_peer_agent_names(subject)
+        assert "a" not in names
+        assert "abc" in names
+        assert "x" * 65 not in names
+
+    # ----------------------------------------------------------------
+    # Discovery capped at 50 siblings.
+    # ----------------------------------------------------------------
+    def test_discovery_capped_at_50_siblings(self, tmp_path):
+        """60 siblings → frozenset has exactly 50."""
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        from rubric_binary_evaluator import discover_peer_agent_names
+
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        subject = agents_dir / "subject.md"
+        subject.write_text("---\nname: subject\n---\nbody\n", encoding="utf-8")
+        for i in range(60):
+            name = f"s{i:02d}"
+            (agents_dir / f"sib-{i:02d}.md").write_text(
+                f"---\nname: {name}\n---\nbody\n", encoding="utf-8"
+            )
+        names = discover_peer_agent_names(subject)
+        assert len(names) == 50


### PR DESCRIPTION
## Summary

Implements issue #206 — adds a deterministic SF-3 binary-rubric check that flags peer-agent name occurrences in agent body text (sibling `agents/*.md` `name:` fields), excluding self, fenced code blocks, and skill artifacts.

The issue calls the criterion "A1"; the canonical repo rubric ID is **SF-3** (continues the SF-1/SF-2 self-containment family per `agent-evaluation-guide.md`). The mapping is documented in the `check_SF_3` docstring and commit body.

## What changed

- `scripts/rubric_binary_evaluator.py` — new `check_SF_3` function; `BINARY_ITEM_IDS` gets `"SF-3"` appended; `_run_check` gets a new dispatch branch; module docstring counts updated (28→29 total, 26→27 for agents, "28 of 29; SF-3 NA" for skills).
- `scripts/rubric_patterns.py` — new `discover_peer_agent_names` (dynamic glob over the agent's parent dir; bounds `3 ≤ len(name) ≤ 64` and ≤50 siblings); new `strip_code_preserve_lines` (newline-preserving fence stripper); new `build_peer_agent_re` with hyphen-resistant boundaries `(?<![\w-])(?![\w-])`.
- Three reference files updated: `scoring-rubric.md` (SF-3 entry + Agent-Items row), `agent-evaluation-guide.md` (Layer-2 row), `merge-rules.md` (BINARY_CAPS `SF-3 | Metadata | C` row).
- 6 new eval-cases (`case_09`..`case_14`) covering AC1, AC2, AC3, AC4a, AC4b, AC4c with matching fixtures + findings JSON.
- Test additions across `tests/test_rubric_pattern_behavior.py` + `tests/test_rubric_binary_evaluator.py` covering: dynamic discovery, self-exclusion, hyphen-boundary, alternation order, CRLF + tilde fences, unclosed-fence cascade, discovery bounds, paired in/out-fence, frontmatter-line-count accuracy, un-frontmatter-degraded-line-numbers, 30-char window edges, mixed long+short names.

## Test plan

- [x] `make validate` — 1068 passed, 0 failed
- [x] `pytest tests/test_rubric_binary_evaluator.py -k SF3 -v` — 18/18
- [x] `pytest tests/test_rubric_pattern_behavior.py -k SF3 -v` — 9/9
- [x] `pytest tests/test_eval_cases.py -k "case_09_sf3 or case_10_sf3 or case_11_sf3 or case_12_sf3 or case_13_sf3 or case_14_sf3" -v` — 6/6
- [x] CI green on this PR (verified post-push)

## Out of scope (per issue boundaries)

- Auto-fix for SF-3 (separate `apply-agent-review-findings` issue)
- Description-side peer-reference detection (META-3* domain)
- Other `review-*` skills
- Active-gameability defenses (case-mismatches, unicode tricks, HTML comments) — SF-3 protects accidental authoring drift only

## Notes for reviewers

- Plan went through 3 review rounds (R1/R2/R3 by team-red + reviewer); both signed off PASS at R3.
- Phase 7.5 Evaluator may emit WARNING on the `scoring-rubric.md` edit per CLAUDE.md §Hard Constraints #6 footnote ("Evaluator surfaces it as WARNING when these files appear in a diff because session boundaries are not diff-checkable") — non-blocking per /implement-issue Phase 7.5 spec.

Closes #206