### PR TITLE
feat(references): add DQ-1..DQ-6 sub-rubric + description conventions (#216)

### DIFF
--- a/skills/review-claude-config/references/agent-description-convention.md
+++ b/skills/review-claude-config/references/agent-description-convention.md
@@ -1,0 +1,59 @@
+---
+name: agent-description-convention
+description: Authoring rules for agent-frontmatter `description:` field — cluster-density-aware length, Quality-First hierarchy, reciprocal counter-case symmetry, lead-with-Use-this-when phrasing.
+last_refreshed: 2026-05-07
+---
+
+# Agent Description Convention
+
+Authoring rules for the `description:` field in agent frontmatter.
+Evidence class follows `description-design-problem.md` — P/E/L/R notation.
+
+## 1. Lead-with "Use this when X" `[E]`
+
+The first sentence of any agent description MUST start with `Use this when …` or
+`Use to …`. This is the Anthropic skill-creator convention for routing precision.
+
+- **PASS:** "Use this when reviewing PR diffs for security regressions."
+- **FAIL:** "Reviews code." (no trigger phrase; generic noun-verb snippet)
+
+## 2. Cluster-Density-Aware Length `[E]`
+
+No hard character cap below Anthropic's 1024-char absolute ceiling. Length scales
+with the number of competing primitives in the same trigger cluster — more
+competition needs more disambiguation tokens. A single-agent repo may succeed with
+40 chars; a 10-agent plugin requires 150–300 chars to route reliably.
+
+Reference: Microsoft 775-tool catalog — collision probability rises sharply when
+descriptions share ≥2 trigger tokens across ≥5 siblings.
+
+## 3. Quality-First / Token-Tiebreaker Hierarchy `[E]`
+
+Quality (DQ-1..3 Purpose/Guidelines/Limitations) is the **primary axis**.
+Token economy is the tiebreaker only when two phrasings have equal DQ-coverage.
+
+Empirical rationale: Saavedra arXiv 2602.14878 — 97.1% of MCP descriptions exhibit
+≥1 smell. Quality gaps dominate; length optimization is secondary.
+
+## 4. Counter-Case Reciprocal Symmetry `[E]`
+
+If primitive A's description says "do NOT use; use B", primitive B's description
+MUST contain a corresponding negative entry naming A.
+
+Example triangle: `review-skill` ↔ `review-agent` ↔ `review-rule`. Each carries
+"Do NOT use for [other-primitive] files — use [sibling] instead."
+
+Asymmetric counter-cases create silent over-triggering when A is absent from B's
+scope exclusions.
+
+## 5. Concrete-User-Phrase Preference `[E]`
+
+Prefer the verbatim phrasing a user types ("review this agent", "audit my repo")
+over abstract task-types ("conduct quality assessment", "perform evaluation").
+
+- **PASS:** "Use when asked to 'review agent' or dispatched by /review-claude-config."
+- **FAIL:** "Performs comprehensive multi-dimensional quality assessment of agent primitives."
+
+## 6. Empirical Anchor Cross-Reference
+
+**Empirical anchor:** see [`description-design-problem.md`](description-design-problem.md) — do not duplicate the empirical numbers here.

--- a/skills/review-claude-config/references/scoring-rubric.md
+++ b/skills/review-claude-config/references/scoring-rubric.md
@@ -122,6 +122,74 @@ sources (Tier-1 cited per item).
 
 Grade boundary: META-1 ✗ → D/F (dispatch failure); META-2 ✗ → C; META-4 ✗ → C (third-person violation = discovery risk); META-3c ✗ → C (no discriminating keyword); all ✓ → B; all ✓ + no sibling overlap → A.
 
+### Description Quality (DQ-1..DQ-6, Likert) — issue #216
+
+DQ-* are **Likert 1–5** (NOT binary). Smell threshold: score < 3 on any applicable item.
+Applies to **Metadata dimension narrative scoring** only — DQ-* are intentionally NOT
+promoted to the binary Item Inventory in this phase (Phase 3 designs the validator).
+Empirical anchor: Saavedra arXiv 2602.14878 (n=856 tool descriptions, 103 MCP servers,
+ICC 0.76–0.90). Per-primitive applicability: see `references/description-design-problem.md`.
+
+- **DQ-1 Purpose** (Likert 1–5; smell <3): description states what the primitive does — its
+  functional intent — clearly enough that a reviewer can predict activation scope without
+  reading the body. *Likert 5:* single crisp sentence covering domain + action + output type.
+  *Likert 1:* restatement of the filename or entirely absent. *Smell <3:* purpose ambiguous or
+  multi-domain without discriminating scope. *Source: Saavedra arXiv 2602.14878.*
+- **DQ-2 Guidelines** (Likert 1–5; smell <3): description states when and how to invoke the
+  primitive — concrete trigger condition, positive use-case phrase, or "Use this when X"
+  framing. *Smell <3:* no trigger phrase, or trigger phrase is vague ("as needed", "if
+  appropriate"). *Source: Saavedra arXiv 2602.14878.*
+- **DQ-3 Limitations** (Likert 1–5; smell <3): description states what the primitive does NOT
+  handle — explicit out-of-scope clause or "Do NOT use for Y" entry. *Smell <3:* no
+  limitations stated; description implies broader scope than the body supports. *Source:
+  Saavedra arXiv 2602.14878.*
+- **DQ-4 Parameters** (Likert 1–5; smell <3): for parameterized primitives (MCP tools, skills
+  with explicit arguments), description explains each parameter's purpose and accepted values.
+  *Smell <3:* required parameters undocumented or semantics ambiguous. *Source: Saavedra arXiv
+  2602.14878.*
+- **DQ-5 Length** (Likert 1–5; smell <3): description length is calibrated to routing
+  precision — neither so short that it cannot discriminate (sparse routing failure) nor so long
+  that it floods context (catalog-economy failure). Cluster-density heuristic: longer
+  descriptions justified in high-competition clusters (≥5 siblings with overlapping triggers).
+  *Smell <3:* description is either a single bare noun/verb with no scope signal, OR exceeds
+  Anthropic's 1024-char ceiling. *Source: Saavedra arXiv 2602.14878.*
+- **DQ-6 Examples** (Likert 1–5; **Optional** — Saavedra ablation showed no statistically
+  significant degradation when DQ-6 alone was removed; treat as bonus signal, not smell-trigger):
+  description includes ≥1 concrete usage example or trigger phrase the user would type verbatim.
+  *Likert 5:* specific example that unambiguously scopes the primitive. *Likert 1:* absent.
+  Optional: DQ-6 absence does NOT raise a smell flag; DQ-6 presence at Likert ≥4 may upgrade
+  Metadata from B to A. *Source: Saavedra arXiv 2602.14878 (ablation result).*
+
+#### Per-Primitive Applicability
+
+Saavedra empirical scope is MCP-Tool only; other columns are extrapolated engineering guidance
+or repo defaults. Evidence class: P=Proven, E=Engineering guidance, L=Low-evidence, R=Repo
+default. Mirrors `references/description-design-problem.md` lines 43–50.
+
+| Component | MCP-Tool | Skill | Agent | Rule |
+|-----------|----------|-------|-------|------|
+| DQ-1 Purpose | ✓ P | ✓ E | ✓ E | ✓ R |
+| DQ-2 Guidelines | ✓ P | ◐ L | ✓ E | ✓ R |
+| DQ-3 Limitations | ✓ P | ◐ L | ✓ E | ✓ R |
+| DQ-4 Parameters | ✓ P | ◐ L | ◐ L | N/A |
+| DQ-5 Length | ✓ P | ✓ E | ✓ E | N/A |
+| DQ-6 Examples | ✓ P | ◐ L | ◐ L | N/A |
+
+#### DQ-* ↔ META-* Mapping
+
+Relations: `complement` = non-overlapping coverage of the same quality axis;
+`redundant` = one subsumes the other (binary vs Likert on same signal);
+`subsume` = DQ-* entirely replaces the META-* signal for this axis.
+
+| DQ Item | Most-related META | Relation | Note |
+|---------|-------------------|----------|------|
+| DQ-1 Purpose | META-1a | complement | DQ-1 = semantic completeness of purpose; META-1a = token-set overlap with body trigger |
+| DQ-2 Guidelines | META-3a | complement | DQ-2 = how/when prose; META-3a = vague-trigger regex absence |
+| DQ-3 Limitations | META-2 | redundant | META-2 binary-checks anti-pattern regex; DQ-3 Likert-checks adequacy of scope exclusion |
+| DQ-4 Parameters | (no META analogue) | complement | argument semantics outside META scope; DQ-4 fills the gap |
+| DQ-5 Length | META-3b/3c | complement | DQ-5 quality of length calibration; META-3b/3c = sibling overlap and discriminating token |
+| DQ-6 Examples | (no META analogue) | complement | optional bonus signal; META-* have no analogous example-presence check |
+
 ### Ambiguity Markers (Clarity B/C discriminator) — issues #66, #69
 
 - **CLAR-1 Fuzzy-Quantifier-Free**: step parameters contain no fuzzy quantifier. *Regex:* `/\b(slightly|a bit|roughly|somewhat|some)\b/i` (skip `some` inside placeholder paths). *PASS:* "fetch 10 entries". *FAIL:* "fetch roughly 10 entries".

--- a/skills/review-claude-config/references/skill-description-convention.md
+++ b/skills/review-claude-config/references/skill-description-convention.md
@@ -1,0 +1,65 @@
+---
+name: skill-description-convention
+description: Authoring rules for skill-frontmatter `description:` field — cluster-density-aware length, Quality-First hierarchy, reciprocal counter-case symmetry, lead-with-Use-this-when phrasing.
+last_refreshed: 2026-05-07
+---
+
+# Skill Description Convention
+
+Authoring rules for the `description:` field in skill frontmatter.
+Evidence class follows `description-design-problem.md` — P/E/L/R notation.
+
+## 1. Lead-with "Use this when X" `[E]`
+
+The first sentence of any skill description MUST start with `Use this when …` or
+`Use to …`. This is the Anthropic skill-creator convention for routing precision.
+
+- **PASS:** "Use this when reviewing a SKILL.md for quality issues."
+- **FAIL:** "Reviews skills." (no trigger phrase; generic noun-verb snippet)
+
+## 2. Cluster-Density-Aware Length `[E]`
+
+No hard character cap below Anthropic's 1024-char absolute ceiling. Length scales
+with the number of competing skills in the same plugin — more siblings in the same
+trigger cluster requires more disambiguation tokens.
+
+Reference: Microsoft 775-tool catalog — collision probability rises sharply when
+descriptions share ≥2 trigger tokens across ≥5 siblings in the same plugin.
+
+## 3. Quality-First / Token-Tiebreaker Hierarchy `[E]`
+
+Quality (DQ-1..3 Purpose/Guidelines/Limitations) is the **primary axis**.
+Token economy is the tiebreaker only when two phrasings have equal DQ-coverage.
+
+Empirical rationale: Saavedra arXiv 2602.14878 — 97.1% of MCP descriptions exhibit
+≥1 smell. Quality gaps dominate; length optimization is secondary.
+
+## 4. Counter-Case Reciprocal Symmetry `[E]`
+
+If skill A's description says "do NOT use; use B", skill B's description MUST
+contain a corresponding negative entry naming A.
+
+Example pair: `review-skill` ↔ `review-agent`. Each description carries an
+explicit "not for [other primitive]" clause pointing to the sibling.
+
+Asymmetric counter-cases create silent over-triggering when A is absent from B's
+scope exclusions.
+
+## 5. Concrete-User-Phrase Preference `[E]`
+
+Prefer the verbatim phrasing a user types ("review this skill", "check my hook")
+over abstract task-types ("evaluate quality of skill artifact").
+
+- **PASS:** "Use when asked to 'review skill' or dispatched by /review-claude-config."
+- **FAIL:** "Performs comprehensive multi-dimensional quality evaluation of skill primitives."
+
+## 6. Skill-Specific Activation Note
+
+Skill body is loaded **only on activation**; SKILL.md ≤ 5,000 tokens (Anthropic
+Agent Skills Specification, April 2026). The `description:` field is the routing
+surface and the **only level-1 token cost** — every byte not needed for routing
+is overhead in every dispatch, not just the first.
+
+## 7. Empirical Anchor Cross-Reference
+
+**Empirical anchor:** see [`description-design-problem.md`](description-design-problem.md) — do not duplicate the empirical numbers here.

--- a/skills/review-claude-config/references/token-budgets.json
+++ b/skills/review-claude-config/references/token-budgets.json
@@ -1,6 +1,6 @@
 {
   "BUDGETS": {
-    "scoring-rubric.md": 12000,
+    "scoring-rubric.md": 13500,
     "tool-grant-decision-tree.md": 800,
     "engineering-baseline.md": 4350,
     "signal-catalog.md": 1400,
@@ -31,7 +31,9 @@
     "injection-regex-library.md": 1500,
     "audit-report-schema.md": 600,
     "context-report-schema.md": 600,
-    "description-design-problem.md": 799
+    "description-design-problem.md": 799,
+    "agent-description-convention.md": 800,
+    "skill-description-convention.md": 800
   },
   "DOMAIN_CACHE_BUDGET": 800,
   "DEFAULT_BUDGET": 500

--- a/tests/test_validate_token_budgets.py
+++ b/tests/test_validate_token_budgets.py
@@ -55,7 +55,7 @@ class TestEstimateTokens:
 
 class TestGetBudget:
     def test_rubric(self, tmp_path):
-        assert get_budget(tmp_path / "scoring-rubric.md") == 12000
+        assert get_budget(tmp_path / "scoring-rubric.md") == 13500
 
     def test_baseline(self, tmp_path):
         assert get_budget(tmp_path / "engineering-baseline.md") == 4350


### PR DESCRIPTION
## Summary

Phase 2 of the description-quality track (#216). Operationalizes Phase 1 (#215) into the suite's two normative artifacts:

1. **Scoring-rubric extension** — new `Description Quality (DQ-1..DQ-6, Likert)` subsection inside Metadata. Six Likert items (Purpose / Guidelines / Limitations / Parameters / Length / Examples) with smell threshold `<3`, per-primitive applicability table mirroring `description-design-problem.md`, and a 6-row DQ-↔-META mapping table (`subsume` / `complement` / `redundant`). DQ-6 marked Optional per Saavedra ablation.
2. **Convention files (CREATE)** — `agent-description-convention.md` and `skill-description-convention.md` codify cluster-density-aware length, Quality-First / Token-Tiebreaker hierarchy, counter-case reciprocal symmetry, lead-with `Use this when X`, concrete-user-phrase preference. Empirical anchors live in `description-design-problem.md` (cross-referenced via markdown link).
3. **Token budgets** — register both new convention files at 800 tokens; raise `scoring-rubric.md` budget from 12000 to 13500 (actual extension ~880 tokens; A2.7 authorises raise with justification).
4. **Test update** — `tests/test_validate_token_budgets.py::TestGetBudget::test_rubric` assertion updated 12000 → 13500 to match raised budget.

### Premise correction (audit-trail)

The issue body claims a legacy `agent-description-convention.md` codifies "hard caps (≤250 chars / ≤15 words)". Pre-implementation `find` + `grep -rE` + `git log --all` showed zero occurrences across `skills/`, `docs/`, and git history. The file was never tracked. A3.1 was interpreted as **CREATE** rather than rewrite; the negative regression checks (A3.1a/b) pass vacuously on a fresh file and serve as forward-regression on future edits.

### Forward-flag for Phase 3 (#217)

DQ-* items are LLM-judged Likert and intentionally NOT added to `BINARY_ITEM_IDS` / Item Inventory / Grade Caps. `scripts/regenerate_merge_policy.py` `EXPECTED_COUNTS` remain `{binary_item_ids: 33, narrative_parent_ids: 15, item_dimension: 34, binary_caps: 22, agent_item_dimension: 36}`. Phase 3 will need to update these counts when DQ-* is promoted to the binary-evaluator.

### Pipeline

Plan went through three Phase-3 review rounds (R1, R2, R3 PASS). All R2 BLOCKING findings closed in r3:
- B1: A2.2 split into P-A2.2 (DQ-1..5 with smell+`<3`) and P-A2.2b (DQ-6 with Optional+ablation)
- B2: predicates extracted to fenced code bank to avoid markdown-table `\|` ambiguity
- F-C3 (CRITICAL): commit-scope changed `feat(rubric,references)` → `feat(references)` (HC#4 single-token regex)

## Test plan

- [x] `make validate` exits 0 (1068 passed)
- [x] `python3 scripts/validate_token_budgets.py` exits 0
- [x] `python3 scripts/regenerate_merge_policy.py` + `git diff --exit-code merge-policy.yaml` (zero inventory drift)
- [x] All AC predicates P-A2.1..A2.7, P-A3.1..A3.5, P-AC.1..AC.4 PASS
- [x] Token margin: agent-convention 661 tokens (83% of 800), skill-convention 719 tokens (90% of 800)
- [x] Both convention files cross-reference `description-design-problem.md` via markdown link
- [x] HC#4 conventional-commit format verified post-commit; body wraps ≤72 chars

Closes #216