### PR TITLE
feat(scripts): description-graph validator + suite self-audit (#217)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,16 @@ jobs:
         run: pip install -e ".[dev]"
       - name: Run tests with coverage
         run: pytest tests/ -v --tb=short --cov=hooks --cov=scripts --cov-report=term-missing
+
+  description-graph:
+    name: Description-Graph Validator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Install with description-graph extra
+        run: pip install -e ".[dev,description-graph]"
+      - name: Run validate-descriptions
+        run: make validate-descriptions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,11 +226,13 @@ Diff-checkable never-violate rules. The `builder-evaluator` subagent enforces th
 | `token-budget` | `make token-budget` | `python3 scripts/validate_token_budgets.py` |
 | `test` | `make test` | `pytest tests/ -v --tb=short` |
 | `test-cov` | `make test-cov` | `pytest tests/ -v --tb=short --cov=hooks --cov=scripts` |
+| `validate-descriptions` | `make validate-descriptions` | Run description-graph validator |
 - Local-dev venv: `.venv/` at repo root; the Makefile auto-detects `.venv/bin/python` when present and falls back to `python3` (CI path). Recreate via `python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"` if missing or corrupt.
 - Domain-cache entries are read-only at runtime; maintainer refresh is hand-edit + commit in source repo (90-day cadence). Runtime researcher findings surface as `### Domain Cache Drift` in the review report — copy into the relevant `references/domain-cache/{key}.md` to refresh.
 - Audit-fix chain: commit review report first, then commit fixes
 - Review, suggest, and audit skills are read-only on analyzed files except for reports (`${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/`)
 - Apply skills and `scaffold-skill` modify files and require confirmation gates
+- When changing primitive descriptions, run `make validate-descriptions` to verify no description-graph regressions (name collisions, reciprocal-asymmetry breaks, token-grade violations)
 
 ## Research References
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.PHONY: validate lint format schema-validate token-budget test test-cov sync-marketplace-ref
+.PHONY: validate lint format schema-validate token-budget validate-descriptions test test-cov sync-marketplace-ref
 
 PYTHON ?= $(shell test -x .venv/bin/python && echo .venv/bin/python || echo python3)
 
-validate: lint format schema-validate token-budget test
+validate: lint format schema-validate token-budget validate-descriptions test
 
 lint:
 	ruff check hooks/ scripts/
@@ -18,6 +18,9 @@ schema-validate:
 
 token-budget:
 	$(PYTHON) scripts/validate_token_budgets.py
+
+validate-descriptions:
+	PYTHON=$(PYTHON) bash bin/run-validate-descriptions.sh
 
 test:
 	$(PYTHON) -m pytest tests/ -v --tb=short

--- a/bin/run-validate-descriptions.sh
+++ b/bin/run-validate-descriptions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Wrapper for validate_description_graph.py used by `make validate-descriptions`.
+# Exit 0 on warnings-only (exit 1 from validator) — tolerated by make validate.
+# Exit 2 propagated as-is (errors present, CI must fail).
+set -uo pipefail
+PY="${PYTHON:-python3}"
+"${PY}" scripts/validate_description_graph.py "$@" || ec=$?
+ec="${ec:-0}"
+if [ "${ec}" -eq 1 ]; then
+  echo "validate_description_graph: warnings only (exit 1) — tolerated by make validate" >&2
+  exit 0
+fi
+exit "${ec}"

--- a/docs/audits/description-graph-2026-05-07.md
+++ b/docs/audits/description-graph-2026-05-07.md
@@ -7,9 +7,9 @@ findings_error: 0
 findings_warning: 22
 flag_rate_pct: 68.2
 calibration_outcome: pass
-sub_issues_filed: []
-sub_issues_capped: 22
-sub_issues_manifest_path: .work/issue-217/findings_manifest.json
+sub_issues_filed: [228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249]
+sub_issues_capped: 0
+sub_issues_manifest_path: null
 ---
 
 # Description-Graph Self-Audit — 2026-05-07
@@ -61,23 +61,43 @@ Three genuine semantic clusters were detected (cosine ≥ 0.85 threshold):
 19 one-directional cross-reference pairs detected. A skill mentions `use X` or `do not use Y; use X`
 in its description, but X's description does not mention the source skill in return.
 
-## Sub-Issue Filing: CAP EXCEEDED
+## Sub-Issue Filing: CAP-OVERRIDE APPROVED — All 22 Filed
 
-`filtered_count = 22 > cap = 15`
+`filtered_count = 22 > cap = 15` triggered the plan §8 step 4 HALT gate.
+Operator (2026-05-08) reviewed the manifest and approved filing all 22
+findings (3 cluster_conflict + 19 reciprocal_asymmetry, all severity=warning,
+zero errors). Issues filed via `mcp__github__issue_write`:
 
-Per plan §8 step 4: sub-issues NOT filed automatically. Manifest written to
-`.work/issue-217/findings_manifest.json`. Operator should review the manifest
-and select top-N findings to file manually via:
+| # | Check | Primitives |
+|---|---|---|
+| #228 | reciprocal_asymmetry | apply-audit-findings → apply-review-findings |
+| #229 | reciprocal_asymmetry | audit-context-budget → audit-repo |
+| #230 | reciprocal_asymmetry | audit-mcp-auth → review-mcp-server |
+| #231 | reciprocal_asymmetry | audit-memory-hygiene → review-claude-md |
+| #232 | reciprocal_asymmetry | check-repo-health → review-claude-config |
+| #233 | reciprocal_asymmetry | develop-hooks → scaffold-rule |
+| #234 | reciprocal_asymmetry | refresh-evidence-coverage → audit-context-budget |
+| #235 | reciprocal_asymmetry | review-analytics → check-repo-health |
+| #236 | reciprocal_asymmetry | review-claude-config → review-skill |
+| #237 | reciprocal_asymmetry | review-claude-md → review-skill |
+| #238 | reciprocal_asymmetry | review-domain-currency → review-skill |
+| #239 | reciprocal_asymmetry | review-rule → review-skill |
+| #240 | reciprocal_asymmetry | review-skill → apply-skill-review-findings |
+| #241 | reciprocal_asymmetry | run-eval-cases → review-claude-config |
+| #242 | reciprocal_asymmetry | scaffold-rule → scaffold-skill |
+| #243 | reciprocal_asymmetry | suggest-skills → review-claude-config |
+| #244 | reciprocal_asymmetry | validate-primitive-dependencies → review-claude-config |
+| #245 | reciprocal_asymmetry | maintain-evidence-layer → review-claude-config |
+| #246 | reciprocal_asymmetry | sync-research-index → review-claude-config |
+| #247 | cluster_conflict | classify-trace-errors ↔ review-session-trace (cosine 0.900) |
+| #248 | cluster_conflict | review-agent ↔ review-rule ↔ review-skill (cosine 0.887) |
+| #249 | cluster_conflict | review-perspective-{clarity,correctness,integration} (cosine 0.917) |
 
-```bash
-gh issue create \
-  --repo Nosmoht/review-claude-config \
-  --label "category: description-quality" \
-  --title "<check> in <path>" \
-  --body "<body per plan §8 template>"
-```
+All issues carry label `category: description-quality`. None auto-staged
+`status: ready` — they remain discovery artifacts pending triage.
 
-Refer to `.work/issue-217/findings_manifest.json` for the full indexed list.
+Refer to `.work/issue-217/findings_manifest.json` for the original indexed
+list; that file is preserved as the audit-time snapshot of validator output.
 
 ## Reproducer
 

--- a/docs/audits/description-graph-2026-05-07.md
+++ b/docs/audits/description-graph-2026-05-07.md
@@ -1,0 +1,96 @@
+---
+generated_by: scripts/validate_description_graph.py
+generated_at: 2026-05-07T20:38:14Z
+repo: Nosmoht/review-claude-config
+findings_total: 22
+findings_error: 0
+findings_warning: 22
+flag_rate_pct: 68.2
+calibration_outcome: pass
+sub_issues_filed: []
+sub_issues_capped: 22
+sub_issues_manifest_path: .work/issue-217/findings_manifest.json
+---
+
+# Description-Graph Self-Audit — 2026-05-07
+
+Produced by `python3 scripts/validate_description_graph.py --repo . --format json`
+as part of Phase 3 of the description-quality track (issue #217).
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Primitives scanned | 44 |
+| Total findings | 22 |
+| Errors | 0 |
+| Warnings | 22 |
+| Flag rate (primitives with ≥1 finding) | 68.2% (30 / 44) |
+| Calibration threshold | ≥30% |
+| Calibration outcome | PASS |
+
+## Check Breakdown
+
+| Check | Count | Severity |
+|---|---|---|
+| `reciprocal_asymmetry` | 19 | warning |
+| `cluster_conflict` | 3 | warning |
+| `f_grade` | 0 | — |
+| `aggregate_budget_warn` | 0 | — |
+| `aggregate_budget_error` | 0 | — |
+| `name_collision` | 0 | — |
+
+## Cluster Conflicts
+
+Three genuine semantic clusters were detected (cosine ≥ 0.85 threshold):
+
+1. **classify-trace-errors / review-session-trace** (max cosine=0.900)
+   — Both skills analyse session traces; descriptions share heavy overlap.
+   Paths: `skills/classify-trace-errors/SKILL.md`, `skills/review-session-trace/SKILL.md`
+
+2. **review-agent / review-rule / review-skill** (max cosine=0.887)
+   — Three peer-review skills share structurally identical description templates.
+   Paths: `skills/review-agent/SKILL.md`, `skills/review-rule/SKILL.md`, `skills/review-skill/SKILL.md`
+
+3. **review-perspective-clarity / review-perspective-correctness / review-perspective-integration** (max cosine=0.917)
+   — Perspective agents share nearly identical descriptions by design (same template).
+   Paths: `agents/review-perspective-clarity.md`, `agents/review-perspective-correctness.md`, `agents/review-perspective-integration.md`
+
+## Reciprocal Asymmetry
+
+19 one-directional cross-reference pairs detected. A skill mentions `use X` or `do not use Y; use X`
+in its description, but X's description does not mention the source skill in return.
+
+## Sub-Issue Filing: CAP EXCEEDED
+
+`filtered_count = 22 > cap = 15`
+
+Per plan §8 step 4: sub-issues NOT filed automatically. Manifest written to
+`.work/issue-217/findings_manifest.json`. Operator should review the manifest
+and select top-N findings to file manually via:
+
+```bash
+gh issue create \
+  --repo Nosmoht/review-claude-config \
+  --label "category: description-quality" \
+  --title "<check> in <path>" \
+  --body "<body per plan §8 template>"
+```
+
+Refer to `.work/issue-217/findings_manifest.json` for the full indexed list.
+
+## Reproducer
+
+```bash
+python3 scripts/validate_description_graph.py --repo . --format json
+python3 scripts/validate_description_graph.py --repo . --format text
+```
+
+## Phase Context
+
+- Phase 1a — description-design-problem reference: #215 (closed)
+- Phase 1b — empirical anchors in baseline: #223 (closed, superseded)
+- Phase 2 — DQ-1..DQ-6 sub-rubric + convention update: #216 (closed)
+- Phase 3 — this validator: #217
+- Phase 4 — per-primitive DQ scoring + skill wrapper: #218
+- Phase 5 — audit-undertriggering skill + eval-cases: #219

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",
+    "hypothesis>=6.0",
+]
+description-graph = [
+    "model2vec>=0.5,<1.0",
 ]
 
 [build-system]

--- a/scripts/validate_description_graph.py
+++ b/scripts/validate_description_graph.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Description-graph validator for Claude Code primitives.
+
+Embedding model: minishlab/potion-base-8M (model2vec, static dense embeddings)
+Pinned revision: bf8b056651a2c21b8d2565580b8569da283cab23  # see EMBEDDING_REVISION
+Token estimator: len(text) // 4  (matches scripts/validate_token_budgets.py:60-65)
+Exit codes: 0 = no findings, 1 = warnings only, 2 = errors present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Literal
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# === Constants ===
+EMBEDDING_MODEL = "minishlab/potion-base-8M"
+# HuggingFace commit SHA, pre-fetched 2026-05-07
+EMBEDDING_REVISION = "bf8b056651a2c21b8d2565580b8569da283cab23"
+# 0.85 threshold from mcp-tef MiniLM calibration; A6.6 validates on potion-base-8M
+SIMILARITY_THRESHOLD = 0.85
+TOKEN_GRADE_BOUNDS = ((100, "A"), (300, "B"), (600, "C"), (1000, "D"))  # >1000=F
+AGGREGATE_WARN, AGGREGATE_ERROR = 65_000, 120_000
+
+try:
+    from model2vec import StaticModel as _SM  # noqa: F401
+
+    EMBEDDINGS_AVAILABLE: bool = True
+except ImportError:
+    EMBEDDINGS_AVAILABLE = False
+
+
+@dataclass(frozen=True, slots=True)
+class Primitive:
+    kind: Literal["skill", "agent", "plugin"]
+    path: str
+    name: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    check: str
+    severity: Literal["error", "warning"]
+    primitives: tuple[str, ...]
+    message: str
+    metadata: dict = field(default_factory=dict)
+
+
+# === Discovery ===
+_FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_NAME_RE = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_DESC_BLOCK_RE = re.compile(r"^description:\s*>?\s*\n((?:[ \t]+.+\n?)+)", re.MULTILINE)
+_DESC_INLINE_RE = re.compile(r"^description:\s*(?!>)(.+)$", re.MULTILINE)
+
+
+def _parse_md(path: pathlib.Path) -> tuple[str, str]:
+    text = path.read_text(encoding="utf-8")
+    fm_m = _FM_RE.match(text)
+    fm = fm_m.group(1) if fm_m else text
+    nm = _NAME_RE.search(fm)
+    name = nm.group(1).strip() if nm else path.stem
+    dm = _DESC_BLOCK_RE.search(fm) or _DESC_INLINE_RE.search(fm)
+    desc = " ".join(ln.strip() for ln in dm.group(1).splitlines() if ln.strip()) if dm else ""
+    return name, desc
+
+
+def discover_primitives(repo_root: pathlib.Path = REPO_ROOT) -> list[Primitive]:
+    prims: list[Primitive] = []
+    for glob in ("skills/*/SKILL.md", ".claude/skills/*/SKILL.md"):
+        for p in sorted(repo_root.glob(glob)):
+            n, d = _parse_md(p)
+            prims.append(Primitive("skill", str(p.relative_to(repo_root)), n, d))
+    for glob in ("agents/*.md", ".claude/agents/*.md"):
+        for p in sorted(repo_root.glob(glob)):
+            n, d = _parse_md(p)
+            prims.append(Primitive("agent", str(p.relative_to(repo_root)), n, d))
+    pj = repo_root / ".claude-plugin" / "plugin.json"
+    if pj.exists():
+        data = json.loads(pj.read_text(encoding="utf-8"))
+        prims.append(
+            Primitive("plugin", str(pj.relative_to(repo_root)), data.get("name", ""), data.get("description", ""))
+        )
+    return prims
+
+
+# === Checks ===
+def check_name_collision(prims: list[Primitive]) -> list[Finding]:
+    by: dict[str, dict[str, list[Primitive]]] = {}
+    for p in prims:
+        by.setdefault(p.kind, {}).setdefault(p.name, []).append(p)
+    findings = []
+    for kind, names in by.items():
+        for name, grp in names.items():
+            if len(grp) > 1:
+                paths = tuple(g.path for g in grp)
+                findings.append(
+                    Finding(
+                        "name_collision",
+                        "error",
+                        paths,
+                        f"Name '{name}' used by {len(grp)} {kind}s: {', '.join(paths)}",
+                        {"kind": kind, "name": name},
+                    )
+                )
+    return findings
+
+
+# Case-insensitive; matches "Do NOT use for X — use /Y" and "do not use; use B"
+_RECIP_RE = re.compile(
+    r"(?:do\s+not\s+use[^;.—\n]*[;.—]\s*|(?<!\w))use\s+/?([A-Za-z][A-Za-z0-9_-]*)\b",
+    re.IGNORECASE,
+)
+
+
+def _recip_targets(desc: str) -> set[str]:
+    return {m.group(1).lstrip("/").lower() for m in _RECIP_RE.finditer(desc)}
+
+
+def check_reciprocal_symmetry(prims: list[Primitive]) -> list[Finding]:
+    name_map = {p.name.lower(): p for p in prims}
+    findings = []
+    for prim in prims:
+        for tgt_name in _recip_targets(prim.description):
+            tgt = name_map.get(tgt_name)
+            if tgt and prim.name.lower() not in _recip_targets(tgt.description):
+                findings.append(
+                    Finding(
+                        "reciprocal_asymmetry",
+                        "warning",
+                        (prim.path, tgt.path),
+                        f"'{prim.name}' → '{tgt.name}' but no back-ref",
+                        {"source": prim.name, "target": tgt.name},
+                    )
+                )
+    return findings
+
+
+def check_semantic_clusters(prims: list[Primitive]) -> list[Finding]:
+    if not EMBEDDINGS_AVAILABLE:
+        return [
+            Finding(
+                "cluster_skipped",
+                "warning",
+                (),
+                "model2vec not installed; cluster check skipped",
+                {"skipped": True, "fix": 'pip install -e ".[description-graph]"'},
+            )
+        ]
+    from model2vec import StaticModel  # noqa: PLC0415
+
+    # NOTE: model2vec StaticModel.from_pretrained() does not support revision= pinning.
+    # EMBEDDING_REVISION is kept as a documentation anchor for the expected HF commit SHA.
+    # Reproducibility relies on the HF Hub cache for the named model version.
+    model = StaticModel.from_pretrained(EMBEDDING_MODEL)
+    vecs = model.encode([p.description or " " for p in prims])
+    n = len(prims)
+    if n < 2:
+        return []
+    sim = vecs @ vecs.T
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if float(sim[i, j]) >= SIMILARITY_THRESHOLD:
+                union(i, j)
+    comps: dict[int, list[int]] = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+    findings = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        paths = tuple(prims[i].path for i in members)
+        max_s = max(float(sim[members[a], members[b]]) for a in range(len(members)) for b in range(a + 1, len(members)))
+        findings.append(
+            Finding(
+                "cluster_conflict",
+                "warning",
+                paths,
+                f"Semantic cluster: {len(members)} primitives share similar descriptions "
+                f"(max cosine={max_s:.3f} ≥ {SIMILARITY_THRESHOLD})",
+                {"max_similarity": round(max_s, 4), "threshold": SIMILARITY_THRESHOLD},
+            )
+        )
+    return findings
+
+
+def _grade(char_count: int) -> str:
+    tokens = char_count // 4
+    for upper, g in TOKEN_GRADE_BOUNDS:
+        if tokens <= upper:
+            return g
+    return "F"
+
+
+def check_token_grades(prims: list[Primitive]) -> list[Finding]:
+    findings = []
+    for p in prims:
+        if _grade(len(p.description)) == "F":
+            tokens = len(p.description) // 4
+            msg = f"Description token grade F ({tokens} tokens > 1000) in '{p.name}'"
+            findings.append(Finding("f_grade", "warning", (p.path,), msg, {"tokens": tokens, "grade": "F"}))
+    return findings
+
+
+def check_aggregate_budget(prims: list[Primitive]) -> list[Finding]:
+    total = sum(len(p.description) for p in prims) // 4
+    paths = tuple(p.path for p in prims)
+    if total >= AGGREGATE_ERROR:
+        msg = f"Aggregate description tokens {total} ≥ {AGGREGATE_ERROR} (error threshold)"
+        return [
+            Finding(
+                "aggregate_budget_error", "error", paths, msg, {"total_tokens": total, "threshold": AGGREGATE_ERROR}
+            )
+        ]
+    if total >= AGGREGATE_WARN:
+        msg = f"Aggregate description tokens {total} ≥ {AGGREGATE_WARN} (warn threshold)"
+        return [
+            Finding(
+                "aggregate_budget_warn", "warning", paths, msg, {"total_tokens": total, "threshold": AGGREGATE_WARN}
+            )
+        ]
+    return []
+
+
+# === Sanitization ===
+# REGEX-LITERAL-BEGIN
+_HOMEDIR_RE = re.compile(r"(/Users|/home)/[A-Za-z0-9_.-]+")
+# REGEX-LITERAL-END
+_RFC1918_RE = re.compile(r"\b(?:10\.|192\.168\.|172\.(?:1[6-9]|2\d|3[01])\.)\d+\.\d+\b")
+
+
+def scrub(text: str) -> str:
+    text = _HOMEDIR_RE.sub("<USER-HOME>", text)
+    text = _RFC1918_RE.sub("<INTERNAL-IP>", text)
+    return text
+
+
+# === Output ===
+def _f2d(f: Finding) -> dict:
+    return {
+        "check": f.check,
+        "severity": f.severity,
+        "primitives": list(f.primitives),
+        "message": f.message,
+        "metadata": f.metadata,
+    }
+
+
+def format_json(findings: list[Finding], total: int) -> str:
+    errs = sum(1 for f in findings if f.severity == "error")
+    warns = sum(1 for f in findings if f.severity == "warning")
+    payload = {
+        "findings": [_f2d(f) for f in findings],
+        "summary": {
+            "total_primitives": total,
+            "findings_total": len(findings),
+            "findings_error": errs,
+            "findings_warning": warns,
+        },
+    }
+    return json.dumps(payload, indent=2)
+
+
+def format_text(findings: list[Finding], total: int) -> str:
+    lines = [f"Description-graph validator — {total} primitives scanned"]
+    if not findings:
+        lines.append("No findings.")
+        return "\n".join(lines) + "\n"
+    for f in findings:
+        tag = "ERROR" if f.severity == "error" else "WARN"
+        lines.append(f"  [{tag}] {f.check}: {f.message}")
+        for prim in f.primitives:
+            lines.append(f"    - {prim}")
+    errs = sum(1 for f in findings if f.severity == "error")
+    warns = sum(1 for f in findings if f.severity == "warning")
+    lines.append(f"Summary: {errs} error(s), {warns} warning(s).")
+    return "\n".join(lines) + "\n"
+
+
+# === Entry ===
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate description graph across Claude Code primitives.")
+    ap.add_argument("--repo", default=str(REPO_ROOT), help="Path to repository root")
+    ap.add_argument("--format", choices=["text", "json"], default="text")
+    args = ap.parse_args()
+    prims = discover_primitives(pathlib.Path(args.repo))
+    findings: list[Finding] = []
+    findings += check_name_collision(prims)
+    findings += check_reciprocal_symmetry(prims)
+    findings += check_semantic_clusters(prims)
+    findings += check_token_grades(prims)
+    findings += check_aggregate_budget(prims)
+    out = format_json(findings, len(prims)) if args.format == "json" else format_text(findings, len(prims))
+    sys.stdout.write(scrub(out))
+    return 2 if any(f.severity == "error" for f in findings) else (1 if findings else 0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_validate_description_graph.py
+++ b/tests/test_validate_description_graph.py
@@ -1,0 +1,426 @@
+"""Tests for scripts/validate_description_graph.py.
+
+Covers ≥20 cases per plan §3 (tests #1-#20):
+  1  no_findings_clean_repo
+  2  name_collision_same_kind
+  3  name_collision_cross_kind_excluded
+  4  reciprocal_asymmetry_canonical_phrase
+  5  reciprocal_grammar_lowercase
+  6  cluster_conflict_above_threshold
+  7  cluster_skipped_when_model2vec_missing
+  8  cluster_connected_components
+  9  f_grade_token_count
+ 10  aggregate_budget_warn
+ 11  aggregate_budget_error
+ 12  empty_repo
+ 13  single_primitive_repo
+ 14  missing_description_field
+ 15  scrub_strips_user_home
+ 16  scrub_strips_rfc1918
+ 17  token_grade_boundaries
+ 18  format_json_shape
+ 19  format_text_human_readable
+ 20  no_homedir_in_script_self
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+import random
+import secrets
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
+import validate_description_graph as vdg
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SKILL_TEMPLATE = """\
+---
+name: {name}
+description: {description}
+---
+# body
+"""
+AGENT_TEMPLATE = """\
+---
+name: {name}
+description: {description}
+---
+# body
+"""
+
+
+def _make_skill(tmp_path: pathlib.Path, name: str, description: str) -> pathlib.Path:
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    p = skill_dir / "SKILL.md"
+    p.write_text(SKILL_TEMPLATE.format(name=name, description=description), encoding="utf-8")
+    return p
+
+
+def _make_agent(tmp_path: pathlib.Path, name: str, description: str) -> pathlib.Path:
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    p = agents_dir / f"{name}.md"
+    p.write_text(AGENT_TEMPLATE.format(name=name, description=description), encoding="utf-8")
+    return p
+
+
+def _make_plugin(tmp_path: pathlib.Path, name: str, description: str) -> pathlib.Path:
+    plugin_dir = tmp_path / ".claude-plugin"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    p = plugin_dir / "plugin.json"
+    p.write_text(json.dumps({"name": name, "description": description}), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — clean repo exits 0
+# ---------------------------------------------------------------------------
+
+def test_no_findings_clean_repo(tmp_path):
+    _make_skill(tmp_path, "alpha", "Runs alpha analysis. Use for alpha tasks only.")
+    _make_skill(tmp_path, "beta", "Runs beta analysis. Use for beta tasks only.")
+    _make_skill(tmp_path, "gamma", "Runs gamma synthesis. Use for gamma aggregation only.")
+    prims = vdg.discover_primitives(tmp_path)
+    assert len(prims) == 3
+    findings = (
+        vdg.check_name_collision(prims)
+        + vdg.check_reciprocal_symmetry(prims)
+        + vdg.check_token_grades(prims)
+        + vdg.check_aggregate_budget(prims)
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — name collision same kind → error
+# ---------------------------------------------------------------------------
+
+def test_name_collision_same_kind(tmp_path):
+    (tmp_path / "skills" / "alpha").mkdir(parents=True)
+    (tmp_path / "skills" / "alpha-dup").mkdir(parents=True)
+    (tmp_path / "skills" / "alpha" / "SKILL.md").write_text(
+        SKILL_TEMPLATE.format(name="alpha", description="First alpha."), encoding="utf-8"
+    )
+    (tmp_path / "skills" / "alpha-dup" / "SKILL.md").write_text(
+        SKILL_TEMPLATE.format(name="alpha", description="Second alpha."), encoding="utf-8"
+    )
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_name_collision(prims)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.check == "name_collision"
+    assert f.severity == "error"
+    assert len(f.primitives) == 2
+    assert all("SKILL.md" in p for p in f.primitives)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — name collision cross-kind is NOT flagged
+# ---------------------------------------------------------------------------
+
+def test_name_collision_cross_kind_excluded(tmp_path):
+    _make_skill(tmp_path, "common", "Skill with name common.")
+    _make_plugin(tmp_path, "common", "Plugin with name common.")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_name_collision(prims)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — reciprocal asymmetry canonical phrase
+# ---------------------------------------------------------------------------
+
+def test_reciprocal_asymmetry_canonical_phrase(tmp_path):
+    # A references B but B has no back-ref
+    _make_skill(tmp_path, "review-skill", "Reviews a single skill. Do NOT use for agents — use /review-agent instead.")
+    _make_skill(tmp_path, "review-agent", "Reviews a single agent. Standalone tool.")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_reciprocal_symmetry(prims)
+    asymmetric = [f for f in findings if f.check == "reciprocal_asymmetry"]
+    assert len(asymmetric) >= 1
+    sources = {f.metadata["source"] for f in asymmetric}
+    assert "review-skill" in sources
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — reciprocal grammar lowercase
+# ---------------------------------------------------------------------------
+
+def test_reciprocal_grammar_lowercase(tmp_path):
+    _make_skill(tmp_path, "tool-a", "do not use this; use /tool-b")
+    _make_skill(tmp_path, "tool-b", "Standalone tool-b description.")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_reciprocal_symmetry(prims)
+    asymmetric = [f for f in findings if f.check == "reciprocal_asymmetry"]
+    sources = {f.metadata["source"] for f in asymmetric}
+    assert "tool-a" in sources
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — cluster conflict above threshold (requires model2vec)
+# ---------------------------------------------------------------------------
+
+def test_cluster_conflict_above_threshold(tmp_path):
+    pytest.importorskip("model2vec")
+    # s1 and s2 share near-identical descriptions (cosine ≥ 0.85 verified against
+    # minishlab/potion-base-8M); s3 is semantically unrelated.
+    _make_skill(tmp_path, "s1", "review skill files for quality issues")
+    _make_skill(tmp_path, "s2", "review skill source files for quality issues")
+    _make_skill(tmp_path, "s3", "schedule remote cron jobs for background execution")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_semantic_clusters(prims)
+    cluster_findings = [f for f in findings if f.check == "cluster_conflict"]
+    # Exactly 1 cluster component expected for (s1, s2); s3 is different
+    assert len(cluster_findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — cluster skipped when model2vec missing
+# ---------------------------------------------------------------------------
+
+def test_cluster_skipped_when_model2vec_missing(monkeypatch):
+    monkeypatch.setattr(vdg, "EMBEDDINGS_AVAILABLE", False)
+    prims = [
+        vdg.Primitive("skill", "skills/a/SKILL.md", "a", "description a"),
+        vdg.Primitive("skill", "skills/b/SKILL.md", "b", "description b"),
+    ]
+    findings = vdg.check_semantic_clusters(prims)
+    assert len(findings) == 1
+    assert findings[0].check == "cluster_skipped"
+    assert findings[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — connected-component closure emits ONE finding per cluster
+# ---------------------------------------------------------------------------
+
+def test_cluster_connected_components(tmp_path):
+    pytest.importorskip("model2vec")
+    # Four descriptions forming one connected component via union-find transitivity.
+    # Pairwise similarities verified against minishlab/potion-base-8M:
+    #   (files, source files)=0.949, (files, source)=0.851, (source files, source)=0.907,
+    #   (source files, sources)=0.868, (source, sources)=0.956 — all ≥0.85 on at least
+    #   one path so all 4 merge into one component.
+    for i, suffix in enumerate(["files", "source files", "source", "sources"]):
+        _make_skill(tmp_path, f"rev-{i}", f"review skill {suffix} for quality issues")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_semantic_clusters(prims)
+    cluster_findings = [f for f in findings if f.check == "cluster_conflict"]
+    # All 4 should be in a single component → ONE finding
+    assert len(cluster_findings) == 1
+    assert len(cluster_findings[0].primitives) == 4
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — F-grade on description >4000 chars
+# ---------------------------------------------------------------------------
+
+def test_f_grade_token_count(tmp_path):
+    long_desc = "word " * 1001  # 5005 chars → 1251 tokens > 1000
+    _make_skill(tmp_path, "long-skill", long_desc.strip())
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_token_grades(prims)
+    assert len(findings) == 1
+    assert findings[0].check == "f_grade"
+    assert findings[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — aggregate budget warn (65k–120k)
+# ---------------------------------------------------------------------------
+
+def test_aggregate_budget_warn(tmp_path):
+    # 70k tokens = 280k chars across 10 skills (28k chars each)
+    for i in range(10):
+        _make_skill(tmp_path, f"big-{i}", "x" * 28_000)
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_aggregate_budget(prims)
+    assert len(findings) == 1
+    assert findings[0].check == "aggregate_budget_warn"
+    assert findings[0].severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — aggregate budget error (>120k)
+# ---------------------------------------------------------------------------
+
+def test_aggregate_budget_error(tmp_path):
+    # 125k tokens = 500k chars
+    for i in range(10):
+        _make_skill(tmp_path, f"huge-{i}", "x" * 50_000)
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_aggregate_budget(prims)
+    assert len(findings) == 1
+    assert findings[0].check == "aggregate_budget_error"
+    assert findings[0].severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — empty repo → no crash
+# ---------------------------------------------------------------------------
+
+def test_empty_repo(tmp_path):
+    prims = vdg.discover_primitives(tmp_path)
+    assert prims == []
+    findings = (
+        vdg.check_name_collision(prims)
+        + vdg.check_reciprocal_symmetry(prims)
+        + vdg.check_token_grades(prims)
+        + vdg.check_aggregate_budget(prims)
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — single primitive → cluster check doesn't crash
+# ---------------------------------------------------------------------------
+
+def test_single_primitive_repo(tmp_path):
+    _make_skill(tmp_path, "solo", "solo skill description")
+    prims = vdg.discover_primitives(tmp_path)
+    assert len(prims) == 1
+    # Should not raise
+    findings = vdg.check_semantic_clusters(prims)
+    # Either skipped or no cluster findings (n<2)
+    cluster_findings = [f for f in findings if f.check == "cluster_conflict"]
+    assert cluster_findings == []
+
+
+# ---------------------------------------------------------------------------
+# Test 14 — missing description field → description=""
+# ---------------------------------------------------------------------------
+
+def test_missing_description_field(tmp_path):
+    skill_dir = tmp_path / "skills" / "no-desc"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: no-desc\n---\n# body\n", encoding="utf-8"
+    )
+    prims = vdg.discover_primitives(tmp_path)
+    assert len(prims) == 1
+    assert prims[0].name == "no-desc"
+    assert prims[0].description == ""
+
+
+# ---------------------------------------------------------------------------
+# Test 15 — scrub strips user-home paths (runtime-constructed)
+# ---------------------------------------------------------------------------
+
+def test_scrub_strips_user_home():
+    # Construct at runtime so no stable user-home path appears in source
+    for prefix in ("/Users", "/home"):
+        rand_user = secrets.token_hex(4)
+        literal = f"{prefix}/{rand_user}/secret/path"
+        scrubbed = vdg.scrub(literal)
+        assert literal not in scrubbed, f"scrub() did not remove {literal!r}"
+        assert "<USER-HOME>" in scrubbed
+
+
+# ---------------------------------------------------------------------------
+# Test 16 — scrub strips RFC1918 addresses (runtime-constructed)
+# ---------------------------------------------------------------------------
+
+def test_scrub_strips_rfc1918():
+    # Construct at runtime: random 172.16.x.x address
+    second = random.randint(16, 31)
+    third = random.randint(0, 255)
+    fourth = random.randint(1, 254)
+    literal = f"172.{second}.{third}.{fourth}"
+    scrubbed = vdg.scrub(literal)
+    assert literal not in scrubbed, f"scrub() did not remove RFC1918 {literal!r}"
+    assert "<INTERNAL-IP>" in scrubbed
+
+
+# ---------------------------------------------------------------------------
+# Test 17 — token grade boundaries monotonicity (hypothesis)
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+@given(chars=st.integers(min_value=0, max_value=40_000))
+@settings(max_examples=200)
+def test_token_grade_boundaries(chars):
+    grade = vdg._grade(chars)
+    tokens = chars // 4
+    # Monotonicity: grade should correspond to correct bucket
+    if tokens <= 100:
+        assert grade == "A"
+    elif tokens <= 300:
+        assert grade == "B"
+    elif tokens <= 600:
+        assert grade == "C"
+    elif tokens <= 1000:
+        assert grade == "D"
+    else:
+        assert grade == "F"
+
+
+# ---------------------------------------------------------------------------
+# Test 18 — format_json shape
+# ---------------------------------------------------------------------------
+
+def test_format_json_shape(tmp_path):
+    _make_skill(tmp_path, "a", "skill a description")
+    prims = vdg.discover_primitives(tmp_path)
+    findings = vdg.check_name_collision(prims)
+    out = vdg.format_json(findings, len(prims))
+    data = json.loads(out)
+    assert isinstance(data["findings"], list)
+    assert isinstance(data["summary"], dict)
+    assert data["summary"]["total_primitives"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 19 — format_text is human-readable (non-JSON first line)
+# ---------------------------------------------------------------------------
+
+def test_format_text_human_readable(tmp_path):
+    _make_skill(tmp_path, "x", "x description")
+    prims = vdg.discover_primitives(tmp_path)
+    out = vdg.format_text([], len(prims))
+    first_line = out.splitlines()[0]
+    try:
+        json.loads(first_line)
+        raise AssertionError(f"First line is valid JSON: {first_line!r}")
+    except json.JSONDecodeError:
+        pass  # Expected — should be human-readable text
+
+
+# ---------------------------------------------------------------------------
+# Test 20 — script source has no literal user-home prefixes
+# (marker comments carve out the _HOMEDIR_RE regex literal)
+# ---------------------------------------------------------------------------
+
+def test_no_homedir_in_script_self():
+    script_path = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "validate_description_graph.py"
+    source = script_path.read_text(encoding="utf-8")
+    # Remove the regex-literal block (which must contain /Users and /home as pattern)
+    lines = source.splitlines()
+    filtered_lines = []
+    in_block = False
+    for line in lines:
+        if "# REGEX-LITERAL-BEGIN" in line:
+            in_block = True
+            continue
+        if "# REGEX-LITERAL-END" in line:
+            in_block = False
+            continue
+        if not in_block:
+            filtered_lines.append(line)
+    filtered = "\n".join(filtered_lines)
+    # Check no hardcoded user-home paths outside the regex literal
+    import re
+    homedir_re = re.compile(r"(/Users|/home)/[A-Za-z]")
+    match = homedir_re.search(filtered)
+    assert match is None, f"Found user-home literal outside regex block at: {match.group()!r}"


### PR DESCRIPTION
## Summary

Phase 3 of the description-quality track. Adds a catalog-graph validator (`scripts/validate_description_graph.py`) detecting four classes of defect that no per-primitive review can catch:

- **`name_collision`** — same `name` field across two same-kind primitives (severity=error)
- **`reciprocal_asymmetry`** — `Do NOT use; use /X` without a back-reference from X (severity=warning)
- **`cluster_conflict`** — semantic clusters via `model2vec` static embeddings (cosine ≥ 0.85, mcp-tef precedent) with connected-component closure to dedupe (severity=warning)
- **`f_grade`** + **`aggregate_budget`** — per-primitive token grading and catalog-aggregate threshold (mcp-checkup scale + LongFuncEval danger zone)

Self-audit run produced `docs/audits/description-graph-2026-05-07.md` with 22 findings on the current 44 primitives (flag rate 68.2% — calibration PASS). All 22 filed as sub-issues (#228–#249) under `category: description-quality` after operator approval (cap-override; plan's 15-issue cap was a defensive bound, AC A6.3 wants one issue per finding).

## Test plan

- [x] `make validate` exits 0 (lint + format + schema-validate + token-budget + validate-descriptions + test)
- [x] `pytest tests/test_validate_description_graph.py -v` — 20/20 passing (incl. union-find cluster closure, scrub() sanitization, hypothesis-based grade-monotonicity, self-grep for hardcoded user-home prefixes)
- [x] `shellcheck bin/run-validate-descriptions.sh` clean
- [x] `make validate-descriptions` exits 0 (warnings tolerated by wrapper, errors propagate)
- [x] CI: new `description-graph` job in `.github/workflows/ci.yml` installs `[dev,description-graph]` extras and runs `make validate-descriptions`
- [x] Self-audit: 22 findings filed as discoverable sub-issues #228–#249 (no auto `status: ready`)
- [x] No primitive descriptions edited in this PR (A6.5 — fixes scheduled separately as the filed sub-issues)

## Hard Constraints sweep

- ✅ No literal user-home prefixes in committed content (test #20 enforces via REGEX-LITERAL-BEGIN/END marker carve-out)
- ✅ No tracker IDs (`NOS-`/`JIRA-`/`LIN-`) anywhere
- ✅ Conventional commit format
- ✅ No mid-session edits to `scoring-rubric.md` or `engineering-baseline.md`
- ✅ `scrub()` strips RFC1918 + user-home from all output paths

## Phase context

- Phase 1a (#215) — description-design-problem reference — closed
- Phase 1b (#223) — empirical anchors — closed (superseded by #216)
- Phase 2 (#216) — DQ-1..DQ-6 sub-rubric + convention update — closed
- **Phase 3 (#217) — this PR**
- Phase 4 (#218) — per-primitive DQ scoring + skill wrapper
- Phase 5 (#219) — audit-undertriggering skill + eval-cases

Closes #217.