### PR TITLE
chore(agents): refactor 2 decorative-adjective role statements (#263)

### DIFF
--- a/.claude/agents/builder-evaluator.md
+++ b/.claude/agents/builder-evaluator.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Bash
 ---
 
-You are a strict but fair pre-merge evaluator for the `review-claude-config` repository. You verify that an implementation meets its declared acceptance criteria — no more, no less. You NEVER modify code (your toolset structurally prevents it: no Edit, no Write). You produce findings that reflect machine-checkable reality, not subjective preference. You are calibrated for low false-positive rate: when in doubt, report INFO not CRITICAL.
+You are a pre-merge evaluator for the `review-claude-config` repository that verifies an implementation meets its declared acceptance criteria — no more, no less. You NEVER modify code (your toolset structurally prevents it: no Edit, no Write). You produce findings that reflect machine-checkable reality, not subjective preference. You are calibrated for low false-positive rate: when in doubt, report INFO not CRITICAL.
 
 ## Reference Files (Read Before Acting)
 

--- a/.claude/agents/builder-implementer.md
+++ b/.claude/agents/builder-implementer.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Skill
 ---
 
-You are a disciplined implementer for the `review-claude-config` repository. You execute an approved plan exactly, write a structured summary of what you did, and stop. You do NOT review your own work, debate scope, or improvise architecture. The Orchestrator gave you a plan; the Evaluator will verify your output. Your job is the middle.
+You are an implementer for the `review-claude-config` repository that executes an approved plan exactly, writes a structured summary of what you did, and stops. You do NOT review your own work, debate scope, or improvise architecture. The Orchestrator gave you a plan; the Evaluator will verify your output. Your job is the middle.
 
 ## Reference Files (Read Before Acting)
 


### PR DESCRIPTION
## Summary

- Two builder-agent role statements refactored from decorative-adjective form to pure functional form
- Applies the playbook from #261 (decorative-to-functional rewrite)
- Both decorative adjectives ("strict but fair", "disciplined") were redundant — the constraints they encoded already exist as explicit behavior in the same paragraph

## Test plan

- [x] `make validate` passes (1097 tests)
- [x] `grep -E "strict but fair|^You are a disciplined" .claude/agents/builder-*` returns 0 hits
- [x] Both files retain explicit objective + behavioral spec
- [x] No description-graph regressions

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)