### PR TITLE
feat(skills): tighten descriptions for 5 weak-trigger skills (#264)

### DIFF
--- a/skills/apply-review-findings/SKILL.md
+++ b/skills/apply-review-findings/SKILL.md
@@ -2,7 +2,10 @@
 name: apply-review-findings
 description: >
   Applies findings from a /review-claude-config batch report to all reviewed
-  files. Use after /review-claude-config on a folder. Do NOT use for
+  files. Triggered manually via `/apply-review-findings [report-path]`. Use
+  when `${HOME}/.claude/plugins/data/claude-config/reports/<repo-slug>/`
+  contains a batch review report (typically `batch-*.md` or a report referenced
+  by /review-claude-config output) with unaddressed findings. Do NOT use for
   single-item reports — use the type-specific /apply-*-review-findings skills.
 argument-hint: "[report-path]"
 allowed-tools: Agent, Read, Edit, Glob, Bash

--- a/skills/develop-hooks/SKILL.md
+++ b/skills/develop-hooks/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: develop-hooks
 description: >
-  Creates a hook script and registers it in hooks.json. Use when adding
-  automation to enforce quality gates, inject context, or control permissions.
+  Creates a hook script and registers it in `hooks/hooks.json`. Triggered
+  manually via `/develop-hooks [hook-type] <hook-name>`. Use when authoring
+  files under `hooks/` for events PreToolUse, PostToolUse, SubagentStart,
+  SubagentStop, or SessionEnd, or when `hooks/hooks.json` needs a new entry.
   Do NOT use for always-on rules — use /scaffold-rule.
 argument-hint: "[hook-type] <hook-name>"
 allowed-tools: Read, Write, Edit, Glob, Bash

--- a/skills/refresh-evidence-coverage/SKILL.md
+++ b/skills/refresh-evidence-coverage/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: refresh-evidence-coverage
 description: >
-  Re-audits the dimension-evidence coverage matrix on a quartärly (90-day)
-  cadence by running per-dimension web research against documented anchor
-  queries, integrating new Tier-1 sources into rubric/baseline/research
-  files. Use when asked to 'refresh evidence coverage' or '/refresh-evidence-coverage'.
-  Do NOT use for fresh research synthesis without prior coverage matrix —
-  use /audit-context-budget or per-dimension issues instead.
+  Re-audits the dimension-evidence coverage matrix by running per-dimension
+  web research against documented anchor queries, integrating new Tier-1
+  sources into rubric/baseline/research files. Triggered manually via
+  `/refresh-evidence-coverage [dimension|all]`. Use when
+  `docs/dimension-evidence-coverage.md` shows `last_audited` >90 days for the
+  target dimension, or when a new Tier-1 paper for that dimension is added
+  under `research/`. Do NOT use for fresh research synthesis without a prior
+  coverage matrix — use /audit-context-budget or per-dimension issues instead.
 argument-hint: "[dimension|all]"
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 disable-model-invocation: true

--- a/skills/suggest-skills/SKILL.md
+++ b/skills/suggest-skills/SKILL.md
@@ -2,9 +2,13 @@
 name: suggest-skills
 description: >
   Analyzes a repository to identify missing Claude Code skills with skeleton
-  SKILL.md per suggestion. Use when setting up Claude Code or expanding skill
-  coverage. Do NOT use for repo-structure audit — use /audit-repo instead.
-  Do NOT use for existing-skill quality review — use /review-claude-config instead.
+  SKILL.md per suggestion. Triggered manually via `/suggest-skills [folder]`.
+  Use when scaffolding initial primitives in a target folder that has no
+  `.claude/skills/` or `agents/` directory, or when known signals
+  (`pyproject.toml`, `Makefile`, repeated error patterns) suggest skill
+  candidates that do not yet exist. Do NOT use for repo-structure audit —
+  use /audit-repo instead. Do NOT use for existing-skill quality review —
+  use /review-claude-config instead.
 argument-hint: [folder]
 allowed-tools: Agent, Bash, Read, Write, Glob, Grep, WebSearch, WebFetch
 disable-model-invocation: true

--- a/skills/validate-primitive-dependencies/SKILL.md
+++ b/skills/validate-primitive-dependencies/SKILL.md
@@ -2,8 +2,11 @@
 name: validate-primitive-dependencies
 description: >
   Maps cross-primitive references and flags integrity problems: broken refs,
-  orphaned files, cycles. Use before committing a skill, after renaming
-  primitives, or as a pre-release gate. Do NOT use for quality review — use
+  orphaned files, cycles. Triggered manually via
+  `/validate-primitive-dependencies [folder]`. Use when a commit diff touches
+  `skills/*/SKILL.md`, `agents/*.md`, `hooks/*.py`, or files under
+  `.claude/skills/`; or after renaming a primitive (`name:` field change); or
+  as a pre-release gate. Do NOT use for quality review — use
   /review-claude-config.
 argument-hint: "[folder]"
 allowed-tools: Agent, Bash, Read, Glob, Grep, Write


### PR DESCRIPTION
## Summary

- 5 SKILL.md frontmatter `description:` fields tightened from intent-vague triggers ("setting up", "quarterly cadence", "before committing", "when adding automation", "after /review-claude-config") to concrete observable triggers (file paths, named events, file-existence conditions).
- All do-NOT clauses preserved.
- Bodies untouched.
- `make validate-descriptions`: 0 errors, 20 pre-existing warnings unchanged.

## Review trail

- Reviewer agent: APPROVE with 1 LOW nit (pre-existing redirect target in refresh-evidence-coverage — out of scope; not introduced by this PR)
- Team-red agent: REWORK with the observation that all 5 skills have `disable-model-invocation: true`, which restricts model-driven auto-dispatch. **Reframing kept** — descriptions are still valuable as inline documentation for human slash-command users and as machine-readable hints for any future routing logic. Commit body documents this trade-off explicitly.

## Test plan

- [x] `make validate` passes (1097 tests)
- [x] `make validate-descriptions`: 0 errors
- [x] Each description ≤ 1024 chars (Anthropic spec)
- [x] All do-NOT clauses retained per AC

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)