### PR TITLE
feat(rubric): add PE-3 functional-role-statement binary check

### DIFF
--- a/scripts/regenerate_merge_policy.py
+++ b/scripts/regenerate_merge_policy.py
@@ -25,10 +25,10 @@ RUBRIC = REPO_ROOT / "skills/review-claude-config/references/scoring-rubric.md"
 YAML_OUT = REPO_ROOT / "skills/review-skill/references/merge-policy.yaml"
 
 EXPECTED_COUNTS: dict[str, int] = {
-    "binary_item_ids": 33,
+    "binary_item_ids": 34,
     "narrative_parent_ids": 15,
-    "item_dimension": 34,
-    "binary_caps": 22,
+    "item_dimension": 35,
+    "binary_caps": 23,
     "agent_item_dimension": 36,
 }
 
@@ -98,7 +98,7 @@ def parse_rubric(text: str) -> dict:
     lines = text.splitlines(keepends=True)
 
     # 1) §Item Inventory → ###Binary-Evaluated Items (33 rows: Item | Dimension)
-    binary_idx = _find_table(lines, "Item Inventory", "Binary-Evaluated Items (skill rubric, 33)")
+    binary_idx = _find_table(lines, "Item Inventory", "Binary-Evaluated Items (skill rubric, 34)")
     binary_rows = _parse_pipe_table(lines, binary_idx)
     binary_item_ids: list[str] = [r[0] for r in binary_rows if r and r[0]]
     item_dimension: dict[str, str] = {}

--- a/scripts/rubric_binary_evaluator.py
+++ b/scripts/rubric_binary_evaluator.py
@@ -84,6 +84,7 @@ from rubric_patterns import (  # noqa: E402
     FUZZY_QUANTIFIER,
     PE_1_PATTERN,
     PE_2_PATTERN,
+    PE_3_TRIGGER,
     WS_2B_BLOCK_MARKER,
     WS_2B_IF_CLAUSE,
     WS_2B_MARKER_WINDOW,
@@ -99,6 +100,8 @@ from rubric_patterns import (  # noqa: E402
     is_third_person,
     passes_clar1,
     passes_clar2,
+    pe_3_classify,
+    pe_3_scope,
     rd_5b_has_mapping_clause,
     rd_5b_schemes_present,
     strip_code,
@@ -1187,6 +1190,32 @@ def check_PE_2(body: str) -> dict:
     return {"verdict": "PASS", "evidence": {"reason": "no hedge in directive prose"}}
 
 
+def check_PE_3(body: str) -> dict:
+    """Functional-role-statement form (scoring-rubric.md §Role-Statement Form).
+
+    Scopes detection to the first ``PE_3_OPENING_LINE_BUDGET`` non-blockquote,
+    non-example-marker body lines of ``strip_code(body)``; locates a
+    ``You are an? <noun-phrase>`` opener and tokenises the noun-phrase
+    against demographic and decoration closed sets. Multi-token scan
+    blocks compound-noun gaming (``Python expert``).
+    """
+    scope = pe_3_scope(body)
+    match = PE_3_TRIGGER.search(scope)
+    if not match:
+        return _na("no body-opening role statement in scope")
+    noun_phrase = match.group(1)
+    verdict, severity, offending = pe_3_classify(noun_phrase)
+    if verdict == "PASS":
+        return _pass(reason="functional role-statement form", noun_phrase=noun_phrase)
+    line = line_of_offset(body, body.find(match.group(0))) if match.group(0) in body else None
+    return _fail(
+        line=line,
+        match=offending,
+        severity=severity,
+        noun_phrase=noun_phrase,
+    )
+
+
 def check_SP_2b(body: str, fm: dict) -> dict:
     tools = tools_list(fm)
     if not tools:
@@ -1648,6 +1677,7 @@ BINARY_ITEM_IDS: list[str] = [
     "SAMP-2",
     "PE-1",
     "PE-2",
+    "PE-3",
     "SP-2b",
     "SP-4b",
     "IJ-1b",
@@ -1720,6 +1750,8 @@ def _run_check(
             return check_PE_1(body)
         if item_id == "PE-2":
             return check_PE_2(body)
+        if item_id == "PE-3":
+            return check_PE_3(body)
         if item_id == "SP-2b":
             return check_SP_2b(body, fm)
         if item_id == "SP-4b":

--- a/scripts/rubric_patterns.py
+++ b/scripts/rubric_patterns.py
@@ -368,6 +368,114 @@ PE_2_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# PE-3 Functional-Role-Statement (scoring-rubric.md §Role-Statement Form).
+# Two-pass check: first locate a `You are an? <noun-phrase>` opener within
+# the in-scope body region, then tokenise the captured noun-phrase and
+# check each token against two closed sets. Multi-token scan blocks the
+# compound-noun gaming vector (`You are a Python expert that …`).
+#
+# Trigger: case-insensitive, multiline; captures the noun-phrase between
+# `You are an?` and the next clause boundary (`that|who|which|,|.`). The
+# 120-char ceiling on the capture prevents runaway matches across body
+# sections.
+PE_3_TRIGGER = re.compile(
+    r"^\s*You are an?\s+([^.\n]{1,120}?)\s+(?:that|who|which|,|\.)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Demographic adjectives — evidence-anchored to arXiv:2602.12285,
+# arXiv:2512.05858, arXiv:2603.18507, arXiv:2311.10054v3. Hyphenated
+# `world-class` is tokenised on `[\s-]+` so its component tokens
+# (`world`, `class`) are included.
+PE_3_DEMOGRAPHIC_TOKENS = frozenset(
+    {
+        "expert",
+        "senior",
+        "experienced",
+        "principal",
+        "world-class",
+        "world",
+        "class",
+        "veteran",
+        "seasoned",
+        "professional",
+    }
+)
+
+# Decoration adjectives — applier-side blacklist mirror from
+# `skills/apply-skill-review-findings/references/skill-fix-guide.md
+# §Decorative-to-Functional Role-Statement Rewrite`. List is illustrative
+# of the documented anti-pattern, not exhaustive; PE-3 detects the
+# closed-list cases deterministically and defers long-tail decoration to
+# narrative perspective review.
+PE_3_DECORATION_TOKENS = frozenset(
+    {
+        "meticulous",
+        "rigorous",
+        "disciplined",
+        "strict",
+        "careful",
+        "thorough",
+        "thoughtful",
+        "pragmatic",
+        "helpful",
+        "friendly",
+        "brilliant",
+        "talented",
+        "exceptional",
+        "extraordinary",
+        "outstanding",
+    }
+)
+
+# PE-3 in-scope body region: first 20 non-blockquote, non-`anti-pattern|
+# before|example` lines after frontmatter close.
+PE_3_OPENING_LINE_BUDGET = 20
+PE_3_EXAMPLE_MARKER = re.compile(
+    r"\b(anti-?pattern|before|example|exemplar)\b",
+    re.IGNORECASE,
+)
+
+
+def pe_3_scope(body: str) -> str:
+    """Return the in-scope body region for PE-3: the first
+    ``PE_3_OPENING_LINE_BUDGET`` non-blockquote, non-example-marker lines
+    of ``strip_code(body)``. Code fences and inline code are stripped first
+    so anti-pattern catalogs inside ```code blocks``` do not trigger PE-3.
+    """
+    stripped = strip_code(body)
+    in_scope: list[str] = []
+    for line in stripped.splitlines():
+        stripped_line = line.lstrip()
+        if stripped_line.startswith(">"):
+            continue
+        if PE_3_EXAMPLE_MARKER.search(line):
+            continue
+        in_scope.append(line)
+        if len(in_scope) >= PE_3_OPENING_LINE_BUDGET:
+            break
+    return "\n".join(in_scope)
+
+
+def pe_3_classify(noun_phrase: str) -> tuple[str, str | None, str | None]:
+    """Classify the captured noun-phrase against the demographic and
+    decoration closed sets. Returns ``(verdict, severity, match)`` where
+    verdict ∈ {"PASS", "FAIL"}, severity ∈ {"High", "Medium", None}, and
+    ``match`` carries the offending lowercase token (or None on PASS).
+
+    Demographic match wins over decoration (higher-severity precedence).
+    Tokens are split on whitespace and hyphens and lowercased.
+    """
+    tokens = [t for t in re.split(r"[\s-]+", noun_phrase.lower()) if t]
+    for token in tokens:
+        if token in PE_3_DEMOGRAPHIC_TOKENS:
+            return ("FAIL", "High", token)
+    for token in tokens:
+        if token in PE_3_DECORATION_TOKENS:
+            return ("FAIL", "Medium", token)
+    return ("PASS", None, None)
+
+
 # Code-fence and inline-code stripping for PE-* checks. PE-1 and PE-2
 # scan prose only — anti-pattern catalogs (boundary exemplars, rule
 # templates, synthetic test artifacts in run-eval-cases) legitimately
@@ -603,6 +711,13 @@ __all__ = [
     "AGENTIC_WRITE_TOOLS",
     "PE_1_PATTERN",
     "PE_2_PATTERN",
+    "PE_3_TRIGGER",
+    "PE_3_DEMOGRAPHIC_TOKENS",
+    "PE_3_DECORATION_TOKENS",
+    "PE_3_OPENING_LINE_BUDGET",
+    "PE_3_EXAMPLE_MARKER",
+    "pe_3_scope",
+    "pe_3_classify",
     "CODE_FENCE",
     "INLINE_CODE",
     "strip_code",

--- a/skills/review-claude-config/references/convergence-rules.yaml
+++ b/skills/review-claude-config/references/convergence-rules.yaml
@@ -31,6 +31,7 @@ DETERMINISTIC_SUBSET:
   - META-4
   - PE-1
   - PE-2
+  - PE-3
   - RD-5
   - RD-5b
   - RL-1

--- a/skills/review-claude-config/references/engineering-baseline-provenance.md
+++ b/skills/review-claude-config/references/engineering-baseline-provenance.md
@@ -1,7 +1,7 @@
 ---
 name: engineering-baseline-provenance
 description: Source provenance map for engineering-baseline.md — used by evidence-layer audits and baseline refresh, not loaded at runtime by review skills
-last_refreshed: 2026-04-12
+last_refreshed: 2026-05-13
 ---
 
 # Engineering Baseline Provenance
@@ -16,7 +16,7 @@ Maps each technique in `engineering-baseline.md` to its backing sources and tier
 | Technique | Evidence Class | Sources | Tier |
 |-----------|---------------|---------|------|
 | Structured Output | Proven result | Schulhoff et al. arXiv:2406.06608 | 1 |
-| Role Priming | Engineering guidance | arXiv:2603.18507; arXiv:2311.10054v3; arXiv:2602.12285 (AAAI 2026) | 1 |
+| Role Priming | Engineering guidance | arXiv:2603.18507; arXiv:2311.10054v3; arXiv:2602.12285 (AAAI 2026); arXiv:2512.05858 (Basil/Mollick, GPQA+MMLU-Pro) | 1 |
 | Stepwise Decision Flow | Engineering guidance | (engineering practice — no primary benchmark) | — |
 | Few-Shot Examples | Engineering guidance | arXiv:2509.13196 (7 models); Anthropic Claude 4 Best Practices, April 2026 | 1 |
 | Constraint Specification | Proven result | Schulhoff et al. arXiv:2406.06608 | 1 |
@@ -32,7 +32,7 @@ Maps each technique in `engineering-baseline.md` to its backing sources and tier
 
 | Technique | Evidence Class | Sources | Tier |
 |-----------|---------------|---------|------|
-| Context Budget | Proven result | Mei et al. arXiv:2507.13334; Anthropic, Effective Context Engineering (2025) | 1 |
+| Context Budget | Proven result | Mei et al. arXiv:2507.13334; Anthropic, Effective Context Engineering (2025); Chroma 2025 Context Rot | 1/2 |
 | Just-in-Time Retrieval | Engineering guidance | Anthropic, Effective Context Engineering (2025) | 1 |
 | Subagent Isolation | Engineering guidance | Anthropic Agent SDK, 26-event hook system with deny>ask>allow priority | 1 |
 | Reference File Separation | Engineering guidance | (engineering practice — no primary benchmark) | — |
@@ -49,7 +49,7 @@ Maps each technique in `engineering-baseline.md` to its backing sources and tier
 | Knowledge Gap Detection | Engineering guidance | (engineering practice — no primary benchmark) | — |
 | Dynamic Tool Loadout | Low-evidence area | (heuristic — no primary benchmark) | — |
 | Context Compression | Engineering guidance | ACON arXiv:2510.00615; Focus arXiv:2601.07190; Context-Folding arXiv:2510.11967 | 1 |
-| Context Placement | Proven result | arXiv:2508.07479 (COLM 2025); arXiv:2510.10276 | 1 |
+| Context Placement | Proven result | arXiv:2508.07479 (COLM 2025); arXiv:2510.10276; Chroma 2025 Context Rot | 1/2 |
 
 ## Tool Design Techniques
 
@@ -67,8 +67,8 @@ Maps each technique in `engineering-baseline.md` to its backing sources and tier
 
 **Anthropic (Tier 1):** Effective Context Engineering (2025); Writing Tools for Agents (2025); Building Effective Agents (2025); Claude 4 Best Practices (April 2026); Effective Harnesses for Long-Running Agents (March 2026); Agent SDK Hooks (April 2026); Claude Code Best Practices (2025).
 
-**Research — arXiv (Tier 1):** Schulhoff et al. arXiv:2406.06608; Mei et al. arXiv:2507.13334; Qi et al. arXiv:2505.16944; arXiv:2603.18507; arXiv:2311.10054v3; arXiv:2602.12285; arXiv:2509.13196; arXiv:2511.20836; arXiv:2603.22608; arXiv:2510.05381; arXiv:2512.02246; arXiv:2510.00615; arXiv:2601.07190; arXiv:2510.11967; arXiv:2508.07479; arXiv:2510.10276; arXiv:2511.02230; arXiv:2512.11147; arXiv:2601.08012.
+**Research — arXiv (Tier 1):** Schulhoff et al. arXiv:2406.06608; Mei et al. arXiv:2507.13334; Qi et al. arXiv:2505.16944; arXiv:2603.18507; arXiv:2311.10054v3; arXiv:2602.12285; arXiv:2512.05858; arXiv:2509.13196; arXiv:2511.20836; arXiv:2603.22608; arXiv:2510.05381; arXiv:2512.02246; arXiv:2510.00615; arXiv:2601.07190; arXiv:2510.11967; arXiv:2508.07479; arXiv:2510.10276; arXiv:2511.02230; arXiv:2512.11147; arXiv:2601.08012.
 
-**Vendor (Tier 2/3):** Fast.io; Maxim.ai; AWS Prescriptive Guidance.
+**Vendor (Tier 2/3):** Fast.io; Maxim.ai; AWS Prescriptive Guidance; Chroma 2025 Context Rot.
 
 Full research details in `research/` files.

--- a/skills/review-claude-config/references/scoring-rubric.md
+++ b/skills/review-claude-config/references/scoring-rubric.md
@@ -240,6 +240,12 @@ justification (when applied) are logged in the report certificate.
 - **PE-1 CoT-Scaffolding**: body (code-fenced exemplars excluded) free of explicit step-by-step reasoning scaffolding (regex `/\b(think\s+step\s+by\s+step|reason\s+(step\s+by\s+step|carefully\s+about)|let'?s\s+think(\s+(about|through))?)\b/i`). FAIL caps PE at C. Source: `research/prompt-engineering/prompt-engineering-techniques.md` §Opus 4.7.
 - **PE-2 Hedge-Free-Directives**: body (code-fenced exemplars excluded) free of hedge phrases in directives (regex `/\b(try\s+to|if\s+possible|as\s+appropriate|when\s+useful)\b/i`). FAIL caps PE at C. Source: `research/prompt-engineering/prompt-engineering-techniques.md` §Opus 4.7.
 
+### Role-Statement Form (PE B/C discriminator) — issue #273
+
+- **PE-3 Functional-Role-Statement**: the body-opening role statement uses functional form (`You are a <noun-phrase> that <verb-phrase>`) without a decorative or demographic adjective inside the noun-phrase. *Verification:* two-pass regex on `strip_code(body)` scoped to the first 20 non-blockquote, non-`anti-pattern|before|example` body lines (scope mirrors `skills/apply-skill-review-findings/references/skill-fix-guide.md §Decorative-to-Functional Role-Statement Rewrite §Out-of-scope`). **Pass 1 (Trigger)**: locate the first match of `/^\s*You are an?\s+([^.\n]{1,120}?)\s+(?:that|who|which|,|\.)/im`; capture group 1 is the role-noun-phrase. If no match → NA. **Pass 2 (Form-check)**: tokenise the captured noun-phrase on `[\s-]+` (whitespace and hyphens) and lowercase each token; for each token, test membership against two closed sets — **Demographic set**: `{expert, senior, experienced, principal, world-class, world, class, veteran, seasoned, professional}` (hyphenated `world-class` tokenises to `world` + `class`, so both root tokens are listed); **Decoration set**: `{meticulous, rigorous, disciplined, strict, careful, thorough, thoughtful, pragmatic, helpful, friendly, brilliant, talented, exceptional, extraordinary, outstanding}`. If any token is in the demographic set → FAIL with `severity: High` (carry the offending token in `evidence.match`). Else if any token is in the decoration set → FAIL with `severity: Medium`. Else → PASS. *Gaming-resistance pair*: the closed-list closure + multi-token scan + body-opening-and-code-stripped location anchor together constitute the intent-grounded predicate per [`engineering-baseline.md §Gaming-Resistant Criteria`](engineering-baseline.md). Closed lists are evidence-anchored (the four arXiv sources below); multi-token scan blocks the compound-noun gaming vector (`You are a Python expert that …` → token `expert` matches even though it is not the first token). *Known scope limitations*: definite-article openers (`You are the strict X`) and decoration moved post-noun (`reviewer of extraordinary skill`) are out-of-scope here and inherit the `skill-fix-guide.md §Limitations` manual-review treatment. *PASS exemplars*: `You are a dependency checker that validates SemVer ranges and reports conflicts.`; `You are an evaluator that verifies acceptance criteria via runnable predicates.`; `You are a security analyst that audits Terraform IAM policies.` *FAIL exemplars (High)*: `You are an expert evaluator that verifies ACs.` (`expert` ∈ demographic); `You are a senior staff engineer that designs Python services.` (`senior` ∈ demographic); `You are a Python expert that explains type-system edge cases.` (multi-token; `expert` ∈ demographic). *FAIL exemplars (Medium)*: `You are a meticulous reviewer that audits skill quality.` (`meticulous` ∈ decoration); `You are a strict but fair evaluator that scores rubrics.` (`strict` ∈ decoration). Source: arXiv:2602.12285 (Cao/Sun/Yue, AAAI 2026 TrustAgent Workshop — demographic personas degrade); arXiv:2512.05858 (Basil/Mollick — expert personas don't improve factual accuracy across 6 model families on GPQA Diamond + MMLU-Pro); arXiv:2603.18507 (Hu/Rostami/Thomason PRISM — expert generative-vs-discriminative trade-off); arXiv:2311.10054v3 (Zheng EMNLP Findings 2024 — 162 roles, MMLU 71.6% → 68.0%). Magnitudes intentionally omitted from the item body pending `docs/research-backlog.md` #7 (paper-body verification).
+
+Grade boundary: PE-3 ✗ → Prompt Engineering capped at C. Severity tag — `High` on demographic-set match (4 Tier-1 sources, evidence-anchored); `Medium` on decoration-set match (one Tier-1 source + applier-side guide). Both feed the same dimension cap; severity differentiates finding emphasis only.
+
 ### Tool-Grant Alignment (Safety B/C discriminator) — issue #69
 
 Rationale: the 2026-04-20 `/review-skill` re-test showed Run-A Integration accepting `Hard Rules`-level tool bindings that Run-B Integration rejected as "not in body" on identical artifacts. Making location agnostic (frontmatter / body / Hard Rules / referenced policy file all count) removes the flip. The un-suffixed IDs `SP-2`, `SP-4`, `IJ-1` are reused with different semantics in `skills/review-settings/references/settings-evaluation-guide.md` and `skills/review-claude-config/references/mcp-evaluation-guide.md` — the `-b` suffix here is specifically to avoid that namespace overlap.
@@ -290,7 +296,7 @@ Grade boundary: agentic items must pass ALL 4 RL-b checks for Safety A; any one 
 
 This section is the canonical source for `BINARY_ITEM_IDS`, `NARRATIVE_PARENT_IDS`, and `ITEM_DIMENSION` consumed by `scripts/merge_findings.py`. CI regenerates `merge-policy.yaml` from these tables — never edit the yaml directly.
 
-### Binary-Evaluated Items (skill rubric, 33)
+### Binary-Evaluated Items (skill rubric, 34)
 
 These items have a deterministic PASS/FAIL/NA verdict from `scripts/rubric_binary_evaluator.py`. The `Dimension` column pins the item to a specific rubric dimension; perspective findings on these items get re-canonicalized in the merge layer (issue #70).
 
@@ -322,6 +328,7 @@ These items have a deterministic PASS/FAIL/NA verdict from `scripts/rubric_binar
 | SAMP-1 | Prompt Engineering |
 | PE-1 | Prompt Engineering |
 | PE-2 | Prompt Engineering |
+| PE-3 | Prompt Engineering |
 | SP-2b | Safety |
 | SP-4b | Safety |
 | IJ-1b | Safety |
@@ -369,6 +376,7 @@ When a binary item FAILs, the dimension is capped at `cap_grade` (cannot be bett
 | CE-X | Context Engineering | C |
 | PE-1 | Prompt Engineering | C |
 | PE-2 | Prompt Engineering | C |
+| PE-3 | Prompt Engineering | C |
 | SAMP-1 | Prompt Engineering | C |
 | SAMP-2 | Metadata | F |
 | META-2 | Metadata | C |

--- a/skills/review-claude-config/references/token-budgets.json
+++ b/skills/review-claude-config/references/token-budgets.json
@@ -1,6 +1,6 @@
 {
   "BUDGETS": {
-    "scoring-rubric.md": 13500,
+    "scoring-rubric.md": 14000,
     "tool-grant-decision-tree.md": 800,
     "engineering-baseline.md": 4350,
     "signal-catalog.md": 1400,

--- a/skills/review-skill/references/merge-policy.yaml
+++ b/skills/review-skill/references/merge-policy.yaml
@@ -30,6 +30,7 @@ binary_item_ids:
 - SAMP-1
 - PE-1
 - PE-2
+- PE-3
 - SP-2b
 - SP-4b
 - IJ-1b
@@ -80,6 +81,7 @@ item_dimension:
   SAMP-1: Prompt Engineering
   PE-1: Prompt Engineering
   PE-2: Prompt Engineering
+  PE-3: Prompt Engineering
   SP-2b: Safety
   SP-4b: Safety
   IJ-1b: Safety
@@ -100,6 +102,7 @@ binary_caps:
   - {item: CE-X, dimension: Context Engineering, cap: C}
   - {item: PE-1, dimension: Prompt Engineering, cap: C}
   - {item: PE-2, dimension: Prompt Engineering, cap: C}
+  - {item: PE-3, dimension: Prompt Engineering, cap: C}
   - {item: SAMP-1, dimension: Prompt Engineering, cap: C}
   - {item: SAMP-2, dimension: Metadata, cap: F}
   - {item: META-2, dimension: Metadata, cap: C}

--- a/tests/test_merge_findings.py
+++ b/tests/test_merge_findings.py
@@ -1397,10 +1397,10 @@ class TestLazyLoadPolicy:
         """Sanity: lazy-loaded values match the YAML committed in the repo."""
         import merge_findings
 
-        assert len(merge_findings.BINARY_ITEM_IDS) == 33
+        assert len(merge_findings.BINARY_ITEM_IDS) == 34
         assert len(merge_findings.NARRATIVE_PARENT_IDS) == 15
-        assert len(merge_findings.ITEM_DIMENSION) == 34
-        assert len(merge_findings.BINARY_CAPS) == 22
+        assert len(merge_findings.ITEM_DIMENSION) == 35
+        assert len(merge_findings.BINARY_CAPS) == 23
         assert len(merge_findings.AGENT_ITEM_DIMENSION) == 36
         # Shape preservation — frozenset of strings, list-of-3-tuples.
         assert isinstance(merge_findings.BINARY_ITEM_IDS, frozenset)

--- a/tests/test_regenerate_merge_policy.py
+++ b/tests/test_regenerate_merge_policy.py
@@ -14,10 +14,10 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import regenerate_merge_policy as rmp  # noqa: E402
 
 EXPECTED = {
-    "binary_item_ids": 33,
+    "binary_item_ids": 34,
     "narrative_parent_ids": 15,
-    "item_dimension": 34,
-    "binary_caps": 22,
+    "item_dimension": 35,
+    "binary_caps": 23,
     "agent_item_dimension": 36,
 }
 

--- a/tests/test_rubric_binary_evaluator.py
+++ b/tests/test_rubric_binary_evaluator.py
@@ -57,6 +57,7 @@ from rubric_binary_evaluator import (  # noqa: E402
     check_RL_4b,
     check_PE_1,
     check_PE_2,
+    check_PE_3,
     check_RL_9b,
     check_SAMP_1,
     check_SAMP_2,
@@ -840,6 +841,72 @@ class TestPE2:
         assert check_PE_2(body)["verdict"] == "PASS"
 
 
+class TestPE3:
+    def test_functional_form_passes(self):
+        body = "You are a dependency checker that validates SemVer ranges."
+        result = check_PE_3(body)
+        assert result["verdict"] == "PASS"
+
+    def test_demographic_prefix_fails_high(self):
+        body = "You are an expert evaluator that verifies ACs."
+        result = check_PE_3(body)
+        assert result["verdict"] == "FAIL"
+        assert result["evidence"]["severity"] == "High"
+        assert result["evidence"]["match"] == "expert"
+
+    def test_senior_demographic_fails_high(self):
+        body = "You are a senior staff engineer that designs Python services."
+        result = check_PE_3(body)
+        assert result["verdict"] == "FAIL"
+        assert result["evidence"]["severity"] == "High"
+        assert result["evidence"]["match"] == "senior"
+
+    def test_multi_token_python_expert_fails_high(self):
+        # Gaming vector: decoration moved off the first token via compound noun.
+        body = "You are a Python expert that explains type-system edge cases."
+        result = check_PE_3(body)
+        assert result["verdict"] == "FAIL"
+        assert result["evidence"]["severity"] == "High"
+        assert result["evidence"]["match"] == "expert"
+
+    def test_decoration_fails_medium(self):
+        body = "You are a meticulous reviewer that audits skill quality."
+        result = check_PE_3(body)
+        assert result["verdict"] == "FAIL"
+        assert result["evidence"]["severity"] == "Medium"
+        assert result["evidence"]["match"] == "meticulous"
+
+    def test_strict_but_fair_decoration_fails_medium(self):
+        body = "You are a strict but fair evaluator that scores rubrics."
+        result = check_PE_3(body)
+        assert result["verdict"] == "FAIL"
+        assert result["evidence"]["severity"] == "Medium"
+        assert result["evidence"]["match"] == "strict"
+
+    def test_no_opener_is_na(self):
+        body = "Workflow starts with reading the file."
+        assert check_PE_3(body)["verdict"] == "NA"
+
+    def test_definite_article_is_na(self):
+        # `You are the …` is out-of-scope per skill-fix-guide §Limitations.
+        body = "You are the strict reviewer that audits PRs."
+        assert check_PE_3(body)["verdict"] == "NA"
+
+    def test_code_fenced_exemplar_does_not_fire(self):
+        body = (
+            "Anti-pattern (do not write this):\n"
+            "```\n"
+            "You are an expert evaluator that verifies ACs.\n"
+            "```\n"
+            "You are a checker that validates ranges.\n"
+        )
+        assert check_PE_3(body)["verdict"] == "PASS"
+
+    def test_blockquoted_exemplar_does_not_fire(self):
+        body = "> You are an expert evaluator that does X.\nYou are a checker that validates ranges.\n"
+        assert check_PE_3(body)["verdict"] == "PASS"
+
+
 class TestSP2b:
     def test_absent_tools_na(self):
         assert check_SP_2b("body", {})["verdict"] == "NA"
@@ -1403,10 +1470,10 @@ class TestSchemaStability:
             assert "evidence" in v, f"{item_id} missing evidence"
             assert isinstance(v["evidence"], dict)
 
-    def test_stats_counts_sum_to_33(self):
+    def test_stats_counts_sum_to_34(self):
         result = evaluate(REVIEW_SKILL_FIXTURE)
         s = result["stats"]
-        assert s["pass"] + s["fail"] + s["na"] == 33
+        assert s["pass"] + s["fail"] + s["na"] == 34
 
 
 REVIEW_SKILL_EXPECTED = {
@@ -1434,6 +1501,7 @@ REVIEW_SKILL_EXPECTED = {
     "SAMP-2": "NA",
     "PE-1": "PASS",
     "PE-2": "PASS",
+    "PE-3": "NA",
     "SP-2b": "PASS",
     "SP-4b": "PASS",
     "IJ-1b": "PASS",  # issue #107: "Validate the file exists" now matches
@@ -1470,6 +1538,7 @@ REVIEW_PERSPECTIVE_CLARITY_AGENT_EXPECTED = {
     "SAMP-2": "NA",
     "PE-1": "PASS",
     "PE-2": "PASS",
+    "PE-3": "NA",
     "SP-2b": "NA",
     "SP-4b": "NA",
     "IJ-1b": "NA",
@@ -1506,6 +1575,7 @@ SCAFFOLD_SKILL_EXPECTED = {
     "SAMP-2": "NA",
     "PE-1": "PASS",
     "PE-2": "PASS",
+    "PE-3": "NA",
     "SP-2b": "PASS",
     "SP-4b": "FAIL",
     "IJ-1b": "PASS",
@@ -1535,7 +1605,7 @@ class TestEndToEndFixtures:
         assert fixture.exists(), f"fixture missing: {fixture}"
         result = evaluate(fixture)
         assert result["stats"]["runner_error"] == 0
-        assert result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"] == 33
+        assert result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"] == 34
         actual = {k: v["verdict"] for k, v in result["verdicts"].items()}
         assert actual == expected
 
@@ -1571,21 +1641,21 @@ class TestRepoWideSmokeStrict:
         result = evaluate(path)
         assert result["stats"]["runner_error"] == 0
         total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-        assert total == 33
+        assert total == 34
 
 
 class TestRepoWideSmokeLenient:
-    """Every skills/*/SKILL.md evaluator invocation returns 33 verdicts;
+    """Every skills/*/SKILL.md evaluator invocation returns 34 verdicts;
     runner_error per skill is logged but not asserted."""
 
-    def test_all_skills_produce_33_verdicts(self):
+    def test_all_skills_produce_34_verdicts(self):
         skills = sorted((REPO_ROOT / "skills").glob("*/SKILL.md"))
         assert len(skills) >= 10, "expected multiple skill targets"
         errors: list[tuple[str, int]] = []
         for p in skills:
             result = evaluate(p)
             total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-            assert total == 33, f"{p}: total {total} != 33"
+            assert total == 34, f"{p}: total {total} != 34"
             if result["stats"]["runner_error"]:
                 errors.append((str(p), result["stats"]["runner_error"]))
         # Surface drift without failing the suite: errors are reported
@@ -1631,9 +1701,9 @@ class TestRunnerErrorHandling:
         p.write_text("", encoding="utf-8")
         result = evaluate(p)
         assert result["stats"]["runner_error"] == 0
-        # All 33 items produce verdicts (mostly NA/FAIL for missing content).
+        # All 34 items produce verdicts (mostly NA/FAIL for missing content).
         total = result["stats"]["pass"] + result["stats"]["fail"] + result["stats"]["na"]
-        assert total == 33
+        assert total == 34
 
     def test_no_frontmatter_no_crash(self, tmp_path):
         p = tmp_path / "body-only.md"

--- a/tests/test_rubric_pattern_behavior.py
+++ b/tests/test_rubric_pattern_behavior.py
@@ -24,6 +24,11 @@ from rubric_patterns import (  # noqa: E402
     LOOP_PATTERN,
     PE_1_PATTERN,
     PE_2_PATTERN,
+    PE_3_DECORATION_TOKENS,
+    PE_3_DEMOGRAPHIC_TOKENS,
+    PE_3_TRIGGER,
+    pe_3_classify,
+    pe_3_scope,
     SECOND_PERSON,
     TERMINATION_PREDICATE,
     _inside_hitl_cycle,
@@ -276,6 +281,100 @@ class TestPE1Pattern:
     )
     def test_match(self, text, expected):
         assert bool(PE_1_PATTERN.search(text)) is expected
+
+
+class TestPE3Pattern:
+    """Role-statement form: ``You are a <noun-phrase> that …`` without
+    decorative/demographic adjectives. Multi-token scan blocks the
+    compound-noun gaming vector (``Python expert``).
+
+    Anchors: scoring-rubric.md §Role-Statement Form; engineering-baseline.md
+    Role Priming entry; skill-fix-guide.md §Decorative-to-Functional
+    Role-Statement Rewrite.
+    """
+
+    @pytest.mark.parametrize(
+        "text,expect_match,expected_capture",
+        [
+            ("You are a checker that validates ranges.", True, "checker"),
+            ("You are an evaluator that verifies ACs.", True, "evaluator"),
+            ("You are a senior staff engineer that designs services.", True, "senior staff engineer"),
+            ("You are a Python expert that explains edge cases.", True, "Python expert"),
+            ("You are the strict reviewer that audits PRs.", False, None),  # definite article — out-of-scope
+            ("Workflow starts with reading the file.", False, None),  # no opener
+            ("", False, None),
+        ],
+        ids=lambda v: repr(v) if isinstance(v, str) else v,
+    )
+    def test_trigger(self, text, expect_match, expected_capture):
+        m = PE_3_TRIGGER.search(text)
+        assert bool(m) is expect_match
+        if m and expected_capture is not None:
+            assert m.group(1) == expected_capture
+
+    @pytest.mark.parametrize(
+        "noun_phrase,verdict,severity,match_token",
+        [
+            ("checker", "PASS", None, None),
+            ("evaluator", "PASS", None, None),
+            ("security analyst", "PASS", None, None),
+            ("dependency checker", "PASS", None, None),
+            ("senior staff engineer", "FAIL", "High", "senior"),
+            ("Python expert", "FAIL", "High", "expert"),
+            ("experienced security analyst", "FAIL", "High", "experienced"),
+            ("world-class reviewer", "FAIL", "High", "world"),
+            ("meticulous reviewer", "FAIL", "Medium", "meticulous"),
+            ("strict but fair evaluator", "FAIL", "Medium", "strict"),
+            ("brilliant agent", "FAIL", "Medium", "brilliant"),
+        ],
+        ids=lambda v: repr(v) if isinstance(v, str) else v,
+    )
+    def test_classify(self, noun_phrase, verdict, severity, match_token):
+        v, sev, tok = pe_3_classify(noun_phrase)
+        assert v == verdict
+        assert sev == severity
+        assert tok == match_token
+
+    def test_demographic_precedence_over_decoration(self):
+        # "senior strict reviewer" carries one demographic + one decoration —
+        # demographic wins the severity tag.
+        v, sev, tok = pe_3_classify("senior strict reviewer")
+        assert v == "FAIL"
+        assert sev == "High"
+        assert tok == "senior"
+
+    def test_scope_strips_code_fences(self):
+        body = (
+            "Heading\n"
+            "```\n"
+            "You are an expert evaluator that does X.\n"
+            "```\n"
+            "You are a checker that validates Y.\n"
+        )
+        # Code-fenced anti-pattern catalog entries must not trigger PE-3.
+        scope = pe_3_scope(body)
+        assert "expert evaluator" not in scope
+        assert "checker that validates" in scope
+
+    def test_scope_skips_blockquote(self):
+        body = "> You are an expert evaluator that does X.\nYou are a checker that validates Y.\n"
+        scope = pe_3_scope(body)
+        assert "expert evaluator" not in scope
+        assert "checker" in scope
+
+    def test_scope_skips_example_marker_lines(self):
+        body = (
+            "Anti-pattern: You are an expert evaluator that does X.\n"
+            "You are a checker that validates Y.\n"
+        )
+        scope = pe_3_scope(body)
+        assert "expert evaluator" not in scope
+        assert "checker" in scope
+
+    def test_closed_sets_disjoint(self):
+        # Demographic and decoration sets are intentionally disjoint —
+        # any overlap would create ambiguous severity tagging.
+        assert PE_3_DEMOGRAPHIC_TOKENS.isdisjoint(PE_3_DECORATION_TOKENS)
 
 
 class TestPE2Pattern:

--- a/tests/test_validate_token_budgets.py
+++ b/tests/test_validate_token_budgets.py
@@ -55,7 +55,7 @@ class TestEstimateTokens:
 
 class TestGetBudget:
     def test_rubric(self, tmp_path):
-        assert get_budget(tmp_path / "scoring-rubric.md") == 13500
+        assert get_budget(tmp_path / "scoring-rubric.md") == 14000
 
     def test_baseline(self, tmp_path):
         assert get_budget(tmp_path / "engineering-baseline.md") == 4350


### PR DESCRIPTION
## Summary

- Adds PE-3 reviewer-side binary check that detects decorative or demographic adjectives in body-opening role statements (`You are an? <noun-phrase> that <verb-phrase>`).
- Closes the reviewer-side gap that PR #268's applier-side rewrite rule already addresses on the fix side — perspective Haiku reviewers no longer need to surface this issue narratively.
- Two-pass regex + multi-token scan blocks the compound-noun gaming vector (`Python expert` flags `expert` in token-2). Closed-list adjectives keep verdicts deterministic across Haiku-class reviewers.
- Empirical sweep across 40 repo skills+agents: 13 PASS, 0 FAIL, 27 NA. Zero regressions in `pytest tests/test_eval_cases.py` (65/65) and `make validate` (1130 passed). Wave 3 empirical-validation report at `${HOME}/.claude/plugins/data/claude-config/reports/review-claude-config/2026-05-13T183825Z-pe3-empirical-validation.md` (out-of-tree per repo convention).

## What changed

`feat(rubric): add PE-3 functional-role-statement binary check` (Wave 2):
- `scoring-rubric.md`: new §Role-Statement Form section; Item Inventory + Grade Caps rows; subsection header bumped 33→34.
- `rubric_patterns.py`: `PE_3_TRIGGER`, `PE_3_DEMOGRAPHIC_TOKENS`, `PE_3_DECORATION_TOKENS`, `pe_3_scope`, `pe_3_classify`.
- `rubric_binary_evaluator.py`: `check_PE_3`, dispatch, `BINARY_ITEM_IDS` append.
- `regenerate_merge_policy.py` + `merge-policy.yaml` + `convergence-rules.yaml`: deterministic-subset updates.
- `token-budgets.json`: scoring-rubric.md 13500→14000 (PE-3 spec ~350 tokens; +500 headroom).
- `tests/test_rubric_pattern_behavior.py`: `TestPE3Pattern` (trigger / classify / scope / closed-set-disjoint).
- `tests/test_rubric_binary_evaluator.py`: `TestPE3` (10 cases); three `*_EXPECTED` dicts gain `"PE-3": "NA"` matching fixture state; item-count assertions updated 33→34 and 34→35.
- `tests/test_merge_findings.py`, `tests/test_regenerate_merge_policy.py`, `tests/test_validate_token_budgets.py`: count assertions updated.

`docs(baseline): add Mollick + Chroma sources to provenance` (predecessor commit; PE-3 cites these sources):
- Provenance map updates only — `engineering-baseline.md` body unchanged (Hard Constraint #6).

## Plan-agent review trail (multi-perspective, pre-implementation)

Two parallel Plan agents (convention-compliance + gaming-resistance) reviewed the draft before implementation:

- **Convention reviewer (ACCEPT-WITH-CHANGES)**: 5/5 PASS, 5/5 NA spot-check on builder/perspective/review/scaffold/develop-hooks artifacts; flagged severity placement (now in grade-boundary paragraph), scope rationale (now cited in item body via skill-fix-guide reference), and EXPECTED_COUNTS verification (verified before commit).
- **Gaming-resistance reviewer (ACCEPT-WITH-CHANGES)**: inversion-test on 7 adversarial inputs identified compound-noun bypass (`Python expert`) as the dominant gaming vector — predicate refined from single-token to multi-token scan to close it. Acknowledged out-of-scope limits (definite-article `the …` form, post-noun decoration) inherit `skill-fix-guide.md §Limitations` manual-review treatment.

## Source evidence

PE-3 closed lists anchor to four Tier-1 sources via `engineering-baseline-provenance.md`:

- arXiv:2602.12285 (Cao/Sun/Yue, AAAI 2026 TrustAgent Workshop)
- arXiv:2512.05858 (Basil/Mollick, GPQA Diamond + MMLU-Pro × 6 models)
- arXiv:2603.18507 (Hu/Rostami/Thomason PRISM)
- arXiv:2311.10054v3 (Zheng EMNLP Findings 2024 — 162 roles)

Magnitudes (e.g. "26.2% degradation") intentionally omitted from the rubric body pending `docs/research-backlog.md` #7 (paper-body verification — abstracts verified, bodies unread). When that work completes, the citation can be augmented additively.

## Test plan

- [x] `make validate` exits 0 (1130 tests pass).
- [x] `make validate-descriptions` exits 0 (warnings only, tolerated).
- [x] `python3 scripts/regenerate_merge_policy.py --check` exits 0.
- [x] `pytest tests/test_eval_cases.py` 65/65 pass (no regression on eval-case detection).
- [x] PE-3 sweep across 40 repo skills+agents: 13 PASS, 0 FAIL, 27 NA.
- [x] 8/8 BOUNDARY exemplars in scoring-rubric.md verified against `check_PE_3`.

## Hard Constraint check

- [x] No hardcoded `$HOME` paths in committed content.
- [x] No external tracker IDs.
- [x] `make validate` passes; no `--no-verify` used.
- [x] Conventional-commit format on both commits.
- [x] No mid-session edits to `engineering-baseline.md` or `scoring-rubric.md` — this session IS the between-sessions edit per the maintainer's session-scoping decision; both files were committed AFTER all session work completed.

Closes: https://github.com/Nosmoht/review-claude-config/issues/273

🤖 Generated with [Claude Code](https://claude.com/claude-code)