### PR TITLE
fix(hooks): isolate policy_gate audit logging from deny enforcement (#159)

### DIFF
--- a/hooks/policy_gate.py
+++ b/hooks/policy_gate.py
@@ -216,24 +216,75 @@ def _check_overrides(overrides, tool_name, tool_input):
 
 
 def _log_decision(plugin_data, input_data, level, action):
-    """Append policy decision to audit trace."""
-    session_id = input_data.get("session_id", "unknown")
-    audit_dir = os.path.join(plugin_data, "audit")
-    os.makedirs(audit_dir, exist_ok=True)
-    path = os.path.join(audit_dir, f"{session_id}.audit.jsonl")
+    """Append policy decision to audit trace.
 
-    entry = {
-        "type": "policy_decision",
-        "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "session_id": session_id,
-        "tool_name": input_data.get("tool_name", "unknown"),
-        "level": level,
-        "level_label": LEVEL_LABELS.get(level, "Unknown"),
-        "action": action,
-        "agent_id": input_data.get("agent_id"),
-    }
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(entry, default=str) + "\n")
+    Side-effect isolation: failures from disk I/O (EACCES, ENOSPC, broken
+    mount) or JSON serialization MUST NOT propagate to main(). Otherwise
+    the top-level except in __main__ would catch them and emit "{}" — a
+    "no decision" output the harness interprets as ALLOW, silently
+    downgrading a deny/ask to an allow on disk-full.
+
+    Catches OSError (disk full, EACCES, ENOENT on mount), TypeError and
+    ValueError (JSON serialization of unexpected types). Broad Exception
+    is deliberately avoided — KeyboardInterrupt / SystemExit must still
+    propagate.
+    """
+    try:
+        session_id = input_data.get("session_id", "unknown")
+        audit_dir = os.path.join(plugin_data, "audit")
+        os.makedirs(audit_dir, exist_ok=True)
+        path = os.path.join(audit_dir, f"{session_id}.audit.jsonl")
+
+        entry = {
+            "type": "policy_decision",
+            "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "session_id": session_id,
+            "tool_name": input_data.get("tool_name", "unknown"),
+            "level": level,
+            "level_label": LEVEL_LABELS.get(level, "Unknown"),
+            "action": action,
+            "agent_id": input_data.get("agent_id"),
+        }
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+    except (OSError, TypeError, ValueError) as e:
+        # stderr only — stdout is reserved for the hook's JSON contract.
+        print(f"Audit log write failed: {e}", file=sys.stderr)
+
+
+def _decision_json(action, level, tool_name):
+    """Build the stdout JSON string for an action (deny/ask/allow/unknown).
+
+    Pure function — no side effects. Returning the string (rather than
+    printing) lets main() emit the permission decision BEFORE any
+    audit-write side effect, so an audit failure cannot displace the
+    JSON contract with the harness.
+    """
+    if action == "allow":
+        return "{}"
+    if action == "ask":
+        label = LEVEL_LABELS.get(level, "Unknown")
+        return json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "ask",
+                    "permissionDecisionReason": f"L{level} ({label}): {tool_name} requires confirmation",
+                }
+            }
+        )
+    if action == "deny":
+        label = LEVEL_LABELS.get(level, "Unknown")
+        return json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"L{level} ({label}): {tool_name} blocked by policy",
+                }
+            }
+        )
+    return "{}"
 
 
 def main():
@@ -262,39 +313,15 @@ def main():
     else:
         action = policy.get(level, "ask")
 
-    # Log the decision to audit trace
-    _log_decision(plugin_data, input_data, level, action)
-
-    if action == "allow":
-        print("{}")
-    elif action == "ask":
-        label = LEVEL_LABELS.get(level, "Unknown")
-        print(
-            json.dumps(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "ask",
-                        "permissionDecisionReason": f"L{level} ({label}): {tool_name} requires confirmation",
-                    }
-                }
-            )
-        )
-    elif action == "deny":
-        label = LEVEL_LABELS.get(level, "Unknown")
-        print(
-            json.dumps(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": f"L{level} ({label}): {tool_name} blocked by policy",
-                    }
-                }
-            )
-        )
-    else:
-        print("{}")
+    # Decide-then-side-effect: emit permission JSON before any audit write
+    # so a _log_decision failure cannot displace it. Outer try is
+    # belt-and-braces in case a future audit backend bypasses the inner
+    # swallow in _log_decision.
+    print(_decision_json(action, level, tool_name))
+    try:
+        _log_decision(plugin_data, input_data, level, action)
+    except Exception as e:  # noqa: BLE001 — audit must not break enforcement
+        print(f"Audit log write failed: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -366,6 +366,142 @@ class TestMain:
         assert entry["action"] == "ask"
 
 
+class TestAuditFailureIsolation:
+    """Audit-log write failures must NEVER displace the deny/ask/allow JSON.
+
+    Regression: prior to this fix, _log_decision raising (disk full,
+    EACCES, broken mount) would bubble to the top-level except in
+    __main__ and emit "{}" — which the harness reads as "no decision"
+    and falls back to allow. A deny silently became an allow.
+
+    The fix has two layers: (a) emit the JSON BEFORE calling
+    _log_decision, and (b) _log_decision swallows OSError/TypeError/
+    ValueError internally and writes to stderr.
+
+    These tests cover the call-site contract by patching _log_decision
+    to raise — exercising the belt-and-braces ordering guarantee — and
+    also assert the stderr surface format.
+    """
+
+    @staticmethod
+    def _raise_disk_full(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    def test_deny_emitted_when_log_decision_raises(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """L5 deny path: disk-full during audit must NOT downgrade to allow."""
+        import policy_gate
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+        policy_data = {
+            "rules": [{"level": "L5", "action": "deny"}],
+            "overrides": [],
+        }
+        (tmp_path / "policy.json").write_text(json.dumps(policy_data))
+
+        input_data = {
+            "session_id": "test",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /tmp"},
+        }
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(input_data)))
+        monkeypatch.setattr(policy_gate, "_log_decision", self._raise_disk_full)
+
+        main()
+        captured = capsys.readouterr()
+
+        # Decision JSON must reach stdout, NOT "{}".
+        output = json.loads(captured.out.strip())
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        # And the failure must surface on stderr in the contracted format.
+        assert captured.err.startswith("Audit log write failed: ")
+        assert "disk full" in captured.err
+
+    def test_ask_emitted_when_log_decision_raises(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """L4 ask path: disk-full during audit must NOT downgrade to allow."""
+        import policy_gate
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+        policy_data = {
+            "rules": [{"level": "L4", "action": "ask"}],
+            "overrides": [],
+        }
+        (tmp_path / "policy.json").write_text(json.dumps(policy_data))
+
+        input_data = {
+            "session_id": "test",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "foo.py"},
+        }
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(input_data)))
+        monkeypatch.setattr(policy_gate, "_log_decision", self._raise_disk_full)
+
+        main()
+        captured = capsys.readouterr()
+
+        output = json.loads(captured.out.strip())
+        assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
+        assert captured.err.startswith("Audit log write failed: ")
+        assert "disk full" in captured.err
+
+    def test_allow_path_still_emits_empty_when_log_decision_raises(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """Allow path: _log_decision raises, hook must still emit "{}" — not
+        an error JSON, not a deny/ask. The stderr message is still required."""
+        import policy_gate
+
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path))
+        policy_data = {
+            "rules": [{"level": "L1", "action": "allow"}],
+            "overrides": [],
+        }
+        (tmp_path / "policy.json").write_text(json.dumps(policy_data))
+
+        input_data = {
+            "session_id": "test",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/some/file"},
+        }
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(input_data)))
+        monkeypatch.setattr(policy_gate, "_log_decision", self._raise_disk_full)
+
+        main()
+        captured = capsys.readouterr()
+
+        assert captured.out.strip() == "{}"
+        assert captured.err.startswith("Audit log write failed: ")
+        assert "disk full" in captured.err
+
+
+class TestLogDecisionInternalIsolation:
+    """The internal try/except in _log_decision itself must swallow disk
+    errors and emit to stderr — independent of main()'s call-site ordering."""
+
+    def test_oserror_in_makedirs_is_swallowed(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        import policy_gate
+
+        def _boom(*_a, **_kw):
+            raise OSError("EACCES on audit dir")
+
+        monkeypatch.setattr(policy_gate.os, "makedirs", _boom)
+        policy_gate._log_decision(
+            str(tmp_path),
+            {"session_id": "s", "tool_name": "Edit"},
+            4,
+            "ask",
+        )
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err.startswith("Audit log write failed: ")
+        assert "EACCES" in captured.err
+
+
 class TestLazyLoadPolicy:
     """Cover the PEP 562 lazy-load path for the 5 JSON-derived constants."""
 


### PR DESCRIPTION
## Summary

Fixes #159 — silent security degradation where a policy deny became an
allow whenever `_log_decision()` raised (disk full, EACCES, broken
`\$CLAUDE_PLUGIN_DATA`).

- Restructured `main()`: emit permission JSON via `_decision_json()` BEFORE the audit write.
- Wrapped `_log_decision()` internally to swallow `OSError`/`TypeError`/`ValueError` to stderr.
- Added call-site `try/except Exception` as belt-and-braces for future audit-backend variants.
- Three new tests cover the deny/ask/allow paths with `_log_decision` patched to raise `OSError`.
- One additional internal-isolation test verifies the inner swallow when `os.makedirs` raises.

## Test plan

- [x] `make validate` exits 0
- [x] `1039 passed, 2 skipped`
- [x] Coverage `hooks/policy_gate.py` held at 89% (floor preserved per AC #9)
- [x] Stderr format `Audit log write failed: <msg>` confirmed in 4 new tests
- [x] Reviewer (security/testing/simplicity) returned APPROVE
- [x] Team-red flagged 3 out-of-scope residuals — follow-up issues to be filed

## Follow-up (out of scope for #159, will be filed)

Team-red surfaced 3 adjacent bypasses NOT covered by this fix's ACs:
1. `_decision_json` fall-through on unrecognized `action` string at L287 (typo in policy.json → silent allow)
2. `_load_policy → _resolve("DEFAULT_POLICY")` can itself raise before the decision JSON is emitted
3. `print()` buffering semantics on piped stdout (interpreter-shutdown edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)