### PR TITLE
feat(bin): pre-ExitPlanMode plan-reference validator (#204)

### DIFF
--- a/bin/validate-plan-references.sh
+++ b/bin/validate-plan-references.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Validate path + section-anchor citations in a plan markdown file.
+# Exit 0 if every backticked path exists and every §"header" found in a
+# co-cited markdown file (or no co-cited file). Exit 1 with one MISSING-*
+# line per failure on stdout. Pre-ExitPlanMode hallucination gate.
+# See issue #204 for context and the Liu et al. (FSE 2025) evidence base.
+set -euo pipefail
+export LC_ALL=C
+
+plan="${1:-}"
+[[ -n "$plan" && -f "$plan" ]] || { echo "validate-plan-references: usage: $0 <plan-path>" >&2; exit 2; }
+
+repo_root=$(git -C "$(dirname "$plan")" rev-parse --show-toplevel 2>/dev/null || dirname "$plan")
+fails=0
+
+# Strip fenced code blocks before extraction so example paths inside ```...``` don't count.
+body=$(awk 'BEGIN{f=0} /^```/{f=!f; next} f==0' "$plan")
+
+# Path check: backticked tokens matching a file-extension whitelist.
+# shellcheck disable=SC2016 # literal backticks bound the markdown inline-code regex
+paths=$(printf '%s\n' "$body" | grep -oE '`[A-Za-z0-9_./-]+\.(py|md|ya?ml|json|toml|sh|txt)`' | tr -d '`' | sort -u)
+while IFS= read -r p; do
+  [[ -z "$p" ]] && continue
+  [[ -e "$repo_root/$p" || -e "$p" ]] || { echo "MISSING-PATH: $p"; fails=$((fails + 1)); }
+done <<< "$paths"
+
+# Anchor check: each §"header" must resolve in the nearest preceding `*.md` token in the same paragraph.
+while IFS= read -r para; do
+  [[ "$para" != *'§"'* ]] && continue
+  # shellcheck disable=SC2016
+  file_re='`[A-Za-z0-9_./-]+\.md`'
+  file=$(printf '%s' "$para" | grep -oE "$file_re" | tail -1 | tr -d '`' || true)
+  while IFS= read -r anchor; do
+    [[ -z "$anchor" ]] && continue
+    if [[ -z "$file" ]]; then
+      echo "WARN-ANCHOR-NO-FILE: §\"$anchor\"" >&2
+      continue
+    fi
+    target="$repo_root/$file"; [[ -f "$target" ]] || target="$file"
+    grep -qE "^#{1,6}[[:space:]]+${anchor}\$" "$target" 2>/dev/null \
+      || { echo "MISSING-ANCHOR: §\"$anchor\" in $file"; fails=$((fails + 1)); }
+  done < <(printf '%s' "$para" | grep -oE '§"[^"]+"' | sed -E 's/^§"(.*)"$/\1/' | sort -u)
+done < <(printf '%s' "$body" | awk 'BEGIN{RS=""} {print; print "\n"}')
+
+exit $(( fails > 0 ? 1 : 0 ))

--- a/tests/fixtures/plan-validation/invalid-plan.md
+++ b/tests/fixtures/plan-validation/invalid-plan.md
@@ -1,0 +1,20 @@
+# Sample plan with hallucinated references
+
+## Goal
+
+Demonstrate that the validator surfaces fabricated paths and bogus
+section anchors.
+
+## Plan
+
+The settings code lives in `scripts/merge-policy.yaml` and the canonical
+helper is `bin/non-existent-tool.sh`. Both are fabricated.
+
+Read `CLAUDE.md` §"Section That Does Not Exist" — the file is real but
+the anchor is invented. The other cited document `docs/missing-doc.md`
+is also fake.
+
+## Real cross-reference for negative-test isolation
+
+`README.md` exists, so this path alone should not trigger a failure;
+only the hallucinated paths above should fail the gate.

--- a/tests/fixtures/plan-validation/valid-plan.md
+++ b/tests/fixtures/plan-validation/valid-plan.md
@@ -1,0 +1,28 @@
+# Sample plan with all real references
+
+## Goal
+
+Demonstrate every cited path resolves and every anchor matches an actual
+heading in the co-cited markdown file.
+
+## Plan
+
+Read the conventions in `CLAUDE.md` §"Hard Constraints" before editing
+configuration. The token-budget enforcement entry point lives in
+`scripts/validate_token_budgets.py` and the budget map is at
+`skills/review-claude-config/references/token-budgets.json`.
+
+The Makefile entry `Makefile` is the canonical CI surface — see
+`CLAUDE.md` §"Architecture" for component naming.
+
+## Fenced block (should be ignored)
+
+```
+This block contains `fake/path/that-does-not-exist.py` and §"Nonexistent
+Header" — neither should be picked up because they live inside a fenced
+code block.
+```
+
+## Out of scope
+
+- Editing the rubric or baseline.

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -1,0 +1,42 @@
+"""Tests for bin/validate-plan-references.sh (issue #204)."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "bin" / "validate-plan-references.sh"
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "plan-validation"
+
+
+def _run(plan: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(SCRIPT), str(plan)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_valid_plan_exits_zero():
+    result = _run(FIXTURES / "valid-plan.md")
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip() == "", f"expected empty stdout, got {result.stdout!r}"
+
+
+def test_invalid_plan_exits_one():
+    result = _run(FIXTURES / "invalid-plan.md")
+    assert result.returncode == 1, (
+        f"expected exit 1, got {result.returncode}; stdout={result.stdout!r}"
+    )
+
+
+def test_invalid_plan_lists_each_failure_on_stdout():
+    result = _run(FIXTURES / "invalid-plan.md")
+    assert result.returncode == 1
+    assert "MISSING-PATH: scripts/merge-policy.yaml" in result.stdout
+    assert "MISSING-PATH: bin/non-existent-tool.sh" in result.stdout
+    assert "MISSING-PATH: docs/missing-doc.md" in result.stdout
+    assert 'MISSING-ANCHOR: §"Section That Does Not Exist" in CLAUDE.md' in result.stdout


### PR DESCRIPTION
## Summary

Closes #204. Deterministic 45-LOC Bash helper that scans a plan markdown
for backticked paths and §\"header\" anchors and verifies each exists
in the repo tree. Catches LLM-fabricated paths before ExitPlanMode.

- \`bin/validate-plan-references.sh\` — 45 LOC, shellcheck clean.
- \`tests/fixtures/plan-validation/{valid,invalid}-plan.md\` — round-trip fixtures.
- \`tests/test_plan_validation.py\` — 3 tests; negative test asserts exit code AND specific MISSING-* strings.

## Test plan

- [x] \`bin/validate-plan-references.sh tests/fixtures/plan-validation/valid-plan.md\` → exit 0, empty stdout
- [x] \`bin/validate-plan-references.sh tests/fixtures/plan-validation/invalid-plan.md\` → exit 1, 3 MISSING-PATH + 1 MISSING-ANCHOR
- [x] \`shellcheck bin/validate-plan-references.sh\` → clean
- [x] \`make validate\` → 1038 passed, 2 skipped
- [x] LOC 45 ≤ 50-line right-altitude budget

## Notes

- Out of scope per issue: \`~/.claude/skills/implement-issue/SKILL.md\` integration (user-local), markdown-TOC parsing, symbol verification.
- Fenced code blocks are stripped before extraction; example paths inside \`\`\`...\`\`\` are intentionally ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)