### PR TITLE
docs(research-dossier): add autonomous-agent-reliability + change-discipline themes (#28)

### DIFF
--- a/docs/evidence-backed-refactor-plan.md
+++ b/docs/evidence-backed-refactor-plan.md
@@ -38,7 +38,7 @@ The foundational scientific-hardening work has been implemented. This roadmap re
 
 ### 2. Operate the evidence-layer maintenance process
 
-- Keep dossier-style evidence artifacts maintained under the process defined in [`evidence-maintenance.md`](/home/nos-ai/workspace/review-claude-config/docs/evidence-maintenance.md).
+- Keep dossier-style evidence artifacts maintained under the process defined in [`evidence-maintenance.md`](evidence-maintenance.md).
 - Keep cited local `research/*` summaries annotated with provenance metadata only, while leaving repo-level interpretation in the dossier.
 
 ### 3. Trim documentation drift further

--- a/docs/evidence-maintenance.md
+++ b/docs/evidence-maintenance.md
@@ -4,7 +4,7 @@ This guide tells maintainers how to classify claims in `review-claude-config` wi
 
 ## Use the Canonical Contract
 
-Repository-level evidence classification is defined in [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md).
+Repository-level evidence classification is defined in [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md).
 
 Use only these classes:
 
@@ -91,13 +91,13 @@ Run an evidence-layer maintenance pass when any of these happen:
 - Evidence-layer upkeep is manual maintainer work, not skill ownership.
 - `refresh-engineering-baseline` remains limited to `engineering-baseline.md`.
 - Local `research/*` provenance annotations are source metadata only.
-- Repo-level interpretation lives in [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md) and [`scientific-research-dossier.md`](/home/nos-ai/workspace/review-claude-config/docs/scientific-research-dossier.md).
+- Repo-level interpretation lives in [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md) and [`scientific-research-dossier.md`](scientific-research-dossier.md).
 - Record contradictions canonically in `docs/scientific-research-dossier.md`, not in local research summaries.
 
 ### Normalization Checks
 
 - Use only the canonical class names from `evidence-contract.md` for repo-level claims.
-- Treat [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md) and [`review-report-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/review-report-contract.md) as the only relevant contract authorities in this area.
+- Treat [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md) and [`review-report-contract.md`](../skills/review-claude-config/references/review-report-contract.md) as the only relevant contract authorities in this area.
 - Before finalizing edits, search for non-canonical class names in `docs/` and `research/`.
 
 ## Ongoing Maintenance

--- a/docs/repo-gap-analysis.md
+++ b/docs/repo-gap-analysis.md
@@ -1,6 +1,6 @@
 # Evidence-Backed Gap Analysis for `review-claude-config`
 
-This document evaluates the current repository against [`scientific-research-dossier.md`](/home/nos-ai/workspace/review-claude-config/docs/scientific-research-dossier.md) after the completed evidence-layer, review-contract, and baseline-guidance cleanup work.
+This document evaluates the current repository against [`scientific-research-dossier.md`](scientific-research-dossier.md) after the completed evidence-layer, review-contract, and baseline-guidance cleanup work.
 
 ## Summary
 
@@ -10,12 +10,12 @@ The repository is now structurally much stronger than the earlier transitional s
 
 ### 1. The canonical evidence layer now exists
 
-- [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md) defines the only canonical repo-wide claim classes.
-- [`engineering-baseline.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/engineering-baseline.md) and the baseline refresh path now use that vocabulary explicitly.
+- [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md) defines the only canonical repo-wide claim classes.
+- [`engineering-baseline.md`](../skills/review-claude-config/references/engineering-baseline.md) and the baseline refresh path now use that vocabulary explicitly.
 
 ### 2. The review/report contract is centralized
 
-- [`review-report-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/review-report-contract.md) is now the canonical report structure for new review outputs.
+- [`review-report-contract.md`](../skills/review-claude-config/references/review-report-contract.md) is now the canonical report structure for new review outputs.
 - Review, apply, analytics, and health-check surfaces have already been aligned to that authority.
 
 ### 3. Prompt/context-first architecture remains evidence-backed
@@ -88,8 +88,8 @@ Required change:
 
 ## Maintenance Actions
 
-- Follow the evidence-layer maintenance process in [`evidence-maintenance.md`](/home/nos-ai/workspace/review-claude-config/docs/evidence-maintenance.md) for cadence, triggers, and precedence.
-- Keep contradictions canonical in [`scientific-research-dossier.md`](/home/nos-ai/workspace/review-claude-config/docs/scientific-research-dossier.md) while keeping local `research/*` files metadata-only.
+- Follow the evidence-layer maintenance process in [`evidence-maintenance.md`](evidence-maintenance.md) for cadence, triggers, and precedence.
+- Keep contradictions canonical in [`scientific-research-dossier.md`](scientific-research-dossier.md) while keeping local `research/*` files metadata-only.
 - Expand provenance annotations to additional local research summaries only when they are promoted into the dossier citation set.
 - Reduce duplicated prose in `README.md`, `CLAUDE.md`, and `docs/skills/*`.
 - Keep canonical contracts authoritative and make the docs point to them rather than restating them.

--- a/docs/scientific-research-dossier.md
+++ b/docs/scientific-research-dossier.md
@@ -4,19 +4,19 @@ Evidence-first research baseline for the repository itself. `review-claude-confi
 
 ## Method
 
-- Scope: research themes already present in [`research/`](/home/nos-ai/workspace/review-claude-config/research), plus the runtime and guidance surfaces that operationalize those themes in `skills/`, `hooks/`, `README.md`, `CLAUDE.md`, `docs/skills/`, and `docs/evidence-maintenance.md`.
+- Scope: research themes already present in [`research/`](../research), plus the runtime and guidance surfaces that operationalize those themes in `skills/`, `hooks/`, `README.md`, `CLAUDE.md`, `docs/skills/`, and `docs/evidence-maintenance.md`.
 - Source policy:
   - Tier 1: official Anthropic / Claude Code docs, official vendor docs, RFCs / specs, peer-reviewed papers, benchmark papers, and primary arXiv papers when no reviewed version is available.
   - Tier 2: engineering blogs or case studies with concrete technical detail and methodology.
   - Tier 3: supplementary community material only when needed for terminology or examples.
-- Classification: use only the canonical classes defined in [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md).
+- Classification: use only the canonical classes defined in [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md).
 - Contradiction handling: when local summaries and fresher primary sources diverge, the stronger source wins and the contradiction must be recorded explicitly.
 
 ## Freshness and Maintenance
 
 - This dossier is a supporting interpretation artifact, not a canonical contract file.
-- Follow the evidence-layer maintenance process defined in [`evidence-maintenance.md`](/home/nos-ai/workspace/review-claude-config/docs/evidence-maintenance.md).
-- Local `research/*` notes provide provenance metadata only. Repo-level claim interpretation remains in this dossier and in [`evidence-contract.md`](/home/nos-ai/workspace/review-claude-config/skills/review-claude-config/references/evidence-contract.md).
+- Follow the evidence-layer maintenance process defined in [`evidence-maintenance.md`](evidence-maintenance.md).
+- Local `research/*` notes provide provenance metadata only. Repo-level claim interpretation remains in this dossier and in [`evidence-contract.md`](../skills/review-claude-config/references/evidence-contract.md).
 
 ## Contradiction Status
 
@@ -132,15 +132,17 @@ Evidence-first research baseline for the repository itself. `review-claude-confi
   https://research.trychroma.com/context-rot
 - Repository and documentation literature already summarized in local `research/*` files where no stronger primary source was found for the repo-specific design question
 
-### Local Research Summaries Used as Repo Evidence
+### Tier 1 Sources Backing Local Research Summaries
 
-- [`research/context-engineering/anthropic-effective-context-engineering.md`](/home/nos-ai/workspace/review-claude-config/research/context-engineering/anthropic-effective-context-engineering.md)
-- [`research/tool-design/anthropic-writing-tools-for-agents.md`](/home/nos-ai/workspace/review-claude-config/research/tool-design/anthropic-writing-tools-for-agents.md)
-- [`research/agent-skills/anthropic-equipping-agents-with-skills.md`](/home/nos-ai/workspace/review-claude-config/research/agent-skills/anthropic-equipping-agents-with-skills.md)
-- [`research/domain-knowledge/domain-knowledge-impact-on-quality.md`](/home/nos-ai/workspace/review-claude-config/research/domain-knowledge/domain-knowledge-impact-on-quality.md)
-- [`research/source-quality/web-research-quality-evaluation.md`](/home/nos-ai/workspace/review-claude-config/research/source-quality/web-research-quality-evaluation.md)
-- [`research/autonomous-agent-reliability/autonomous-agent-reliability.md`](/home/nos-ai/workspace/review-claude-config/research/autonomous-agent-reliability/autonomous-agent-reliability.md) — added 2026-05-18 (issue #28); MAST taxonomy + R1–R10 rubric
-- [`research/change-discipline/change-discipline-workflow-research.md`](/home/nos-ai/workspace/review-claude-config/research/change-discipline/change-discipline-workflow-research.md) — added 2026-05-18 (issue #28); multi-perspective review canon
+Each local `research/*` mirror file in this repo summarizes one or more canonical Tier 1 papers. The links below point to the canonical source; the parenthetical names the local mirror that distills it.
+
+- Anthropic, "Effective context engineering for AI agents" — https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents (local mirror: `research/context-engineering/anthropic-effective-context-engineering.md`)
+- Anthropic, "Writing tools for agents" — https://www.anthropic.com/engineering/writing-tools-for-agents (local mirror: `research/tool-design/anthropic-writing-tools-for-agents.md`)
+- Claude blog, "Equipping agents for the real world with agent skills" — https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills (local mirror: `research/agent-skills/anthropic-equipping-agents-with-skills.md`)
+- "How to Build AI Agents by Augmenting LLMs with Codified Human Expert Domain Knowledge?" arXiv:2601.15153 — https://arxiv.org/abs/2601.15153; "Procedural Knowledge Improves Agentic LLM Workflows" arXiv:2511.07568 — https://arxiv.org/abs/2511.07568 (local mirror: `research/domain-knowledge/domain-knowledge-impact-on-quality.md`)
+- "Automatic Credibility Assessment Survey" arXiv:2410.21360 — https://arxiv.org/abs/2410.21360; CRAAP Test (Meriam Library, CSU Chico); Google E-E-A-T Quality Rater Guidelines (local mirror: `research/source-quality/web-research-quality-evaluation.md`)
+- Wu et al., "Multi-Agent System Failure Taxonomy (MAST)" arXiv:2503.13657 — https://arxiv.org/abs/2503.13657; "Towards a Science of AI Agent Reliability" arXiv:2602.16666 — https://arxiv.org/abs/2602.16666; AGENTIF (arXiv:2505.16944) — https://arxiv.org/abs/2505.16944 (local mirror: `research/autonomous-agent-reliability/autonomous-agent-reliability.md`, added 2026-05-18 issue #28; MAST taxonomy + R1–R10 rubric)
+- "Mind the Blind Spots: A Focus-Level Evaluation Framework for LLM Reviews" arXiv:2502.17086 — https://arxiv.org/abs/2502.17086; Augment Code, "Code Review Best Practices That Actually Scale"; Kim/Yegge, "The Three Developer Loops" (IT Revolution) (local mirror: `research/change-discipline/change-discipline-workflow-research.md`, added 2026-05-18 issue #28; multi-perspective review canon)
 
 ## Open Questions
 

--- a/docs/scientific-research-dossier.md
+++ b/docs/scientific-research-dossier.md
@@ -55,6 +55,8 @@ Evidence-first research baseline for the repository itself. `review-claude-confi
 | Agent definition quality benchmarks | The repo reviews agent definitions but no academic benchmark exists for this task | KDD 2025 survey (arXiv:2507.21504); ICLR 2026 Workshop (arXiv:2604.00594); arXiv:2602.16666 | No design-time benchmark exists. IRT decomposition, prompt robustness, and instruction density provide proxy evaluation dimensions. Requirements engineering quality frameworks exist as adjacent untested prior art. | Medium | Engineering guidance | New checklist items (TC-3, DA-5, AP-4) fill the gap with research-backed proxies. Composite system is Low-evidence area until validated. |
 | Web scraping / WebFetch augmentation | Some research steps rely on fetching full articles beyond search snippets | Tooling docs and retrieval literature | Full-content retrieval is often needed because snippets are insufficient for evaluation-quality synthesis. | Medium | Engineering guidance | Retain WebFetch/WebSearch separation with strict filtering and attribution. |
 | Hooks as quality gates | The plugin injects quality guidance and freshness warnings automatically | Claude Code hooks docs | Hooks are a supported mechanism for project and plugin lifecycle checks. | High | Engineering guidance | Keep hook guidance high-signal and lightweight. |
+| Autonomous-agent reliability | The plugin runs agentic review/audit workflows whose failures are otherwise silent | MAST taxonomy (arXiv:2503.13657, kappa=0.88 inter-annotator, 94 % LLM-judge accuracy); arXiv:2602.16666 "Science of AI Agent Reliability" (12-metric decomposition); AgentIF (arXiv:2505.16944) showing <30 % perfect adherence | 14 named MAST failure modes, four architectural patterns (circuit-breaker / idempotency / progressive fallback / bounded execution), and a 10-criterion R1–R10 rubric section codified in `research/autonomous-agent-reliability/autonomous-agent-reliability.md`. Reliability is independent of raw accuracy. | High | Proven result | Safety and Context-Engineering rubric items reference MAST IDs (FM-1.2 / FM-2.3 / FM-2.6 / FM-3.1 / FM-3.2). New R10 (observability hooks) is filed against PostToolUse/SubagentStart trace surfaces. |
+| Change discipline / multi-perspective review | The plugin enforces plan → review → implement → commit and dispatches 2–3 perspective agents per plan | Augment Code review-scale study (PRs <400 LOC capture 66–75 % defects); Kim/Yegge *Three Developer Loops* (IT Revolution); arXiv:2502.17086 *Mind the Blind Spots* (F1=0.126 LLM self-review weakness on novelty); Salesforce Prizm engineering blog | LLMs underweight non-technical dimensions during self-review; cross-model + cross-perspective dispatch materially mitigates. Six named agentic failure modes each map to a specific constraint mechanism (shortcuts, premature completion, review fatigue, decision delegation, knowledge loss, quality residue). | Medium-High | Engineering guidance | Justifies the "No plan without multi-perspective review" hard rule, the `reviewer.md` + `team-red.md` dispatch chain on auth/migration paths, and the SIMPLE/COMPLEX ceremony scaling in `docs/change-discipline-rule.md`. |
 
 ## Cross-Theme Findings
 
@@ -111,6 +113,12 @@ Evidence-first research baseline for the repository itself. `review-claude-confi
   https://arxiv.org/abs/2507.13334
 - Qi et al., "AGENTIF: Benchmarking Instruction Following of Large Language Models in Agentic Scenarios" (arXiv:2505.16944)  
   https://arxiv.org/abs/2505.16944
+- Wu et al., "Multi-Agent System Failure Taxonomy (MAST)" (arXiv:2503.13657) — 14 failure modes, kappa=0.88 inter-annotator agreement, 94 % LLM-judge accuracy  
+  https://arxiv.org/abs/2503.13657
+- "Towards a Science of AI Agent Reliability" (arXiv:2602.16666) — 12-metric decomposition across consistency / robustness / predictability / safety  
+  https://arxiv.org/abs/2602.16666
+- "Mind the Blind Spots: A Focus-Level Evaluation Framework for LLM Reviews" (arXiv:2502.17086) — F1=0.126 LLM self-review weakness on non-technical dimensions  
+  https://arxiv.org/abs/2502.17086
 - "How to Build AI Agents by Augmenting LLMs with Codified Human Expert Domain Knowledge?" (arXiv:2601.15153)  
   https://arxiv.org/html/2601.15153
 - "Procedural Knowledge Improves Agentic LLM Workflows" (arXiv:2511.07568)  
@@ -131,6 +139,8 @@ Evidence-first research baseline for the repository itself. `review-claude-confi
 - [`research/agent-skills/anthropic-equipping-agents-with-skills.md`](/home/nos-ai/workspace/review-claude-config/research/agent-skills/anthropic-equipping-agents-with-skills.md)
 - [`research/domain-knowledge/domain-knowledge-impact-on-quality.md`](/home/nos-ai/workspace/review-claude-config/research/domain-knowledge/domain-knowledge-impact-on-quality.md)
 - [`research/source-quality/web-research-quality-evaluation.md`](/home/nos-ai/workspace/review-claude-config/research/source-quality/web-research-quality-evaluation.md)
+- [`research/autonomous-agent-reliability/autonomous-agent-reliability.md`](/home/nos-ai/workspace/review-claude-config/research/autonomous-agent-reliability/autonomous-agent-reliability.md) — added 2026-05-18 (issue #28); MAST taxonomy + R1–R10 rubric
+- [`research/change-discipline/change-discipline-workflow-research.md`](/home/nos-ai/workspace/review-claude-config/research/change-discipline/change-discipline-workflow-research.md) — added 2026-05-18 (issue #28); multi-perspective review canon
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Closes #28 (E4: Update scientific research dossier for completed research topics).

Adds two missing themes to \`docs/scientific-research-dossier.md\`:

- **autonomous-agent-reliability** — MAST taxonomy (14 failure modes; kappa=0.88), 12-metric reliability decomposition, R1–R10 rubric. Maps to MAST FM-1.2 / FM-2.3 / FM-2.6 / FM-3.1 / FM-3.2 in current Safety / CE rubric items.
- **change-discipline** — multi-perspective review canon supporting the existing "No plan without multi-perspective review" hard rule.

Tier-1 source register gains: arXiv:2503.13657 (MAST), arXiv:2602.16666 (reliability science), arXiv:2502.17086 (LLM self-review blindspots).

Local-research summaries gains 2 entries dated 2026-05-18.

## Test plan

- [x] \`make validate\` → 1035 passed, 2 skipped
- [x] Both new theme rows present in matrix (\`autonomous-agent-reliability\`, \`change-discipline\`)
- [x] 3 new Tier-1 arXiv anchors in Source Register
- [x] 2 new local-summary entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)