### PR TITLE
fix(hooks): close policy_gate fail-open on unrecognized action and load-policy raise

### DIFF
--- a/hooks/policy_gate.py
+++ b/hooks/policy_gate.py
@@ -167,21 +167,50 @@ def __getattr__(name: str) -> Any:  # PEP 562
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def _safe_resolve(name, default):
+    """Resolve a lazy name from canonical policy_gate.json; return `default`
+    (with stderr warn) on any raise.
+
+    Used by classification paths (_classify_tool, _classify_mcp_tool) so a
+    missing or corrupted canonical config does NOT propagate through to
+    __main__'s top-level except → silent allow ("{}"). Companion to
+    _safe_resolve_default which guards the DEFAULT_POLICY resolve. Phase 7.5
+    evaluator finding (issue #277 follow-up): the v3 plan covered
+    _resolve("DEFAULT_POLICY") but left TOOL_LEVELS, L5_BASH_PATTERNS,
+    _MCP_L1_PREFIXES, _MCP_L4_VERBS as fall-open paths in the same defect class.
+    """
+    try:
+        return _resolve(name)
+    except Exception as e:  # noqa: BLE001 — defense-in-depth catch-all
+        sys.stderr.write(
+            f"policy_gate: _resolve({name!r}) raised {type(e).__name__}: {e!s}; "
+            f"falling back to {default!r} (fail-closed #278 follow-up)\n"
+        )
+        return default
+
+
 def _classify_mcp_tool(tool_name):
     """Classify an mcp__ tool by name pattern. Default L4 for unknown suffixes."""
     if "__" not in tool_name:
         return 4  # malformed name — conservative fallback
     suffix = tool_name.split("__")[-1]
-    is_l1_shape = any(suffix.startswith(p) for p in _resolve("_MCP_L1_PREFIXES")) or suffix.endswith("_read")
-    has_l4_verb = bool(set(suffix.split("_")) & _resolve("_MCP_L4_VERBS"))
+    is_l1_shape = any(suffix.startswith(p) for p in _safe_resolve("_MCP_L1_PREFIXES", ())) or suffix.endswith("_read")
+    has_l4_verb = bool(set(suffix.split("_")) & _safe_resolve("_MCP_L4_VERBS", frozenset()))
     if is_l1_shape and not has_l4_verb:
         return 1
     return 4
 
 
 def _classify_tool(tool_name, tool_input):
-    """Return authorization level (1-5) for a tool call."""
-    level = _resolve("TOOL_LEVELS").get(tool_name, 4)  # unknown tools default to L4
+    """Return authorization level (1-5) for a tool call.
+
+    Every _resolve(...) call routes through _safe_resolve so a missing
+    or corrupted canonical config cannot propagate to __main__'s top-level
+    catch-all (which would emit "{}" = silent allow). Fail-closed defaults
+    on resolution failure: empty TOOL_LEVELS → every tool defaults to L4;
+    empty L5_BASH_PATTERNS → no L5 escalation but Bash stays at L4.
+    """
+    level = _safe_resolve("TOOL_LEVELS", {}).get(tool_name, 4)  # unknown tools default to L4
 
     # MCP tools: pattern-based classification (reads vs mutations vs unknown)
     if tool_name.startswith("mcp__"):
@@ -190,7 +219,7 @@ def _classify_tool(tool_name, tool_input):
     # Bash escalation check
     if tool_name == "Bash" and level == 4:
         command = tool_input.get("command", "")
-        for pattern in _resolve("L5_BASH_PATTERNS"):
+        for pattern in _safe_resolve("L5_BASH_PATTERNS", []):
             if re.search(pattern, command, re.IGNORECASE):
                 return 5
 

--- a/hooks/policy_gate.py
+++ b/hooks/policy_gate.py
@@ -161,9 +161,31 @@ def _resolve(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+# Per-name fail-closed defaults for the PEP 562 facade. Every lazy name MUST
+# appear here so a missing/corrupted canonical config cannot reach module-attribute
+# consumers (telemetry hooks, audit summaries, future external readers) with an
+# unguarded raise. Same defect class as #278 but on the module's public surface.
+# Without this map, `policy_gate.TOOL_LEVELS` from a future caller bypasses
+# _safe_resolve entirely. Phase 8.5 team-red R2 finding.
+_LAZY_DEFAULTS: dict[str, Any] = {
+    "TOOL_LEVELS": {},
+    "L5_BASH_PATTERNS": [],
+    "DEFAULT_POLICY": None,  # sentinel; resolved below to hardcoded fail-closed copy
+    "_MCP_L1_PREFIXES": (),
+    "_MCP_L4_VERBS": frozenset(),
+}
+
+
 def __getattr__(name: str) -> Any:  # PEP 562
     if name in _LAZY_NAMES:
-        return _resolve(name)
+        # Route through _safe_resolve so the module-attribute facade inherits
+        # the same fail-closed posture as internal _classify_* callsites.
+        # Without this, external consumers re-introduce the #278 bypass.
+        if name == "DEFAULT_POLICY":
+            # DEFAULT_POLICY default is the hardcoded fail-closed posture, not
+            # an empty dict (which would route every L1..L5 lookup to L=4 ask).
+            return _safe_resolve(name, dict(_HARDCODED_FAILCLOSED_POLICY))
+        return _safe_resolve(name, _LAZY_DEFAULTS[name])
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/hooks/policy_gate.py
+++ b/hooks/policy_gate.py
@@ -19,6 +19,7 @@ import os
 import pathlib
 import re
 import sys
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -31,6 +32,21 @@ if TYPE_CHECKING:
     _MCP_L4_VERBS: frozenset[str]
 
 LEVEL_LABELS = {1: "Read", 2: "Analyze", 3: "Recommend", 4: "Act", 5: "Irreversible"}
+
+# Defense-in-depth fail-closed posture for #278.
+# Used ONLY when _resolve("DEFAULT_POLICY") raises (canonical policy_gate.json
+# unreachable or corrupted). Intentionally stricter than canonical default_policy
+# (which is L1-L3 allow, L4 ask, L5 deny) to make sessions degrade conservatively.
+# DO NOT refactor into _resolve(...) call: the duplication IS the defense — if
+# the canonical source is unreachable, this hardcoded copy MUST remain reachable
+# in-process. See issue #278 and plan.md §Hardcoded fail-closed default.
+# MappingProxyType wraps a plain dict to make module-level state read-only,
+# defending against in-process mutation by sibling tests or compromised callers
+# (per v2 reviewer team-red H_T2). Callers MUST defensively `dict(...)` to copy
+# before returning since downstream code may need a mutable dict.
+_HARDCODED_FAILCLOSED_POLICY = MappingProxyType({1: "ask", 2: "ask", 3: "ask", 4: "deny", 5: "deny"})
+
+_VALID_ACTIONS = frozenset({"allow", "ask", "deny"})
 
 _LAZY_NAMES = frozenset(
     {
@@ -181,8 +197,73 @@ def _classify_tool(tool_name, tool_input):
     return level
 
 
+def _validated_action(raw_action, where, default="ask"):
+    """Return raw_action if it's a recognized action verb, else default + stderr warn.
+
+    Called from both policy-rule loading and override-rule loading so the
+    fail-closed default reaches every action-string parse site at load time.
+
+    `where` is repr-escaped before formatting to prevent attacker-controlled
+    policy.json byte injection into stderr (which the harness captures into
+    the orchestrator context per rules/tool-error-contract.md). v2 reviewer
+    team-red H_T3.
+    """
+    if isinstance(raw_action, str) and raw_action in _VALID_ACTIONS:
+        return raw_action
+    sys.stderr.write(
+        f"policy_gate: unrecognized action {raw_action!r} at {where!r}; substituting {default!r} (fail-closed)\n"
+    )
+    return default
+
+
+def _safe_resolve_default():
+    """Return canonical DEFAULT_POLICY, OR hardcoded fail-closed dict on any raise.
+
+    Catches the documented raise classes from _resolve → _load_config_cached:
+    RuntimeError (from _minimal_shape_check + 'policy_gate.json missing'),
+    jsonschema.exceptions.ValidationError (schema-invalid canonical),
+    FileNotFoundError, json.JSONDecodeError. Imports jsonschema lazily inside
+    the function to preserve graceful-degradation when jsonschema is not
+    importable (matches the conditional-import pattern in _load_config_cached).
+    Final `except Exception` is the defense-in-depth catch-all for unforeseen
+    raise classes; KeyboardInterrupt / SystemExit / MemoryError still propagate
+    via Python's BaseException hierarchy.
+    """
+    # Lazy-imported tuple — match _load_config_cached's pattern.
+    failure_types = [RuntimeError, FileNotFoundError, json.JSONDecodeError]
+    try:
+        import jsonschema  # may itself raise ImportError
+
+        failure_types.append(jsonschema.exceptions.ValidationError)
+    except ImportError:
+        pass  # ValidationError won't be raised if jsonschema is unimportable
+
+    try:
+        return _resolve("DEFAULT_POLICY")
+    except tuple(failure_types) as e:
+        sys.stderr.write(
+            f"policy_gate: _resolve(DEFAULT_POLICY) raised {type(e).__name__}: {e!s}; "
+            f"falling back to hardcoded fail-closed posture (#278)\n"
+        )
+        return dict(_HARDCODED_FAILCLOSED_POLICY)
+    except Exception as e:  # noqa: BLE001 — defense-in-depth catch-all
+        sys.stderr.write(
+            f"policy_gate: _resolve(DEFAULT_POLICY) raised unforeseen {type(e).__name__}: {e!s}; "
+            f"falling back to hardcoded fail-closed posture (#278)\n"
+        )
+        return dict(_HARDCODED_FAILCLOSED_POLICY)
+
+
 def _load_policy(plugin_data):
-    """Load policy from file. Return None if no policy file exists (opt-in design)."""
+    """Load policy from file. Return None if no policy file exists (opt-in design).
+
+    Both action-string parsing and the canonical-default fallback use
+    fail-closed semantics: unrecognized action verbs are substituted with
+    "ask" + stderr warn (#277 R3); _resolve raises yield a hardcoded
+    fail-closed dict (#278 R1). OSError (PermissionError on policy.json,
+    stale-mount, etc.) is added to the except tuple to close the parallel
+    fall-open path on the user policy.json file (v2 reviewer M_R1).
+    """
     policy_path = os.path.join(plugin_data, "policy.json")
     if not os.path.isfile(policy_path):
         return None, []  # No policy file = pass-through, zero enforcement
@@ -193,11 +274,20 @@ def _load_policy(plugin_data):
         for rule in data.get("rules", []):
             level_str = rule.get("level", "")
             if level_str.startswith("L") and level_str[1:].isdigit():
-                policy[int(level_str[1:])] = rule.get("action", "ask")
+                raw_action = rule.get("action", "ask")
+                policy[int(level_str[1:])] = _validated_action(raw_action, f"rule level={level_str}")
+        # Validate override actions at load time too — same defect class as rules.
         overrides = data.get("overrides", [])
-        return policy if policy else _resolve("DEFAULT_POLICY"), overrides
-    except (json.JSONDecodeError, KeyError, TypeError):
-        return _resolve("DEFAULT_POLICY"), []
+        for override in overrides:
+            if "action" in override:
+                override["action"] = _validated_action(
+                    override["action"],
+                    f"override tool={override.get('tool', '?')} path={override.get('path_pattern', '?')}",
+                    default="ask",
+                )
+        return policy if policy else _safe_resolve_default(), overrides
+    except (json.JSONDecodeError, KeyError, TypeError, OSError):
+        return _safe_resolve_default(), []
 
 
 def _check_overrides(overrides, tool_name, tool_input):
@@ -255,10 +345,9 @@ def _log_decision(plugin_data, input_data, level, action):
 def _decision_json(action, level, tool_name):
     """Build the stdout JSON string for an action (deny/ask/allow/unknown).
 
-    Pure function — no side effects. Returning the string (rather than
-    printing) lets main() emit the permission decision BEFORE any
-    audit-write side effect, so an audit failure cannot displace the
-    JSON contract with the harness.
+    Pure function — no side effects. Returning the string lets main() emit
+    the permission decision BEFORE any audit-write side effect, so an audit
+    failure cannot displace the JSON contract with the harness.
     """
     if action == "allow":
         return "{}"
@@ -284,7 +373,25 @@ def _decision_json(action, level, tool_name):
                 }
             }
         )
-    return "{}"
+    # #277 R1 — unrecognized action verb (string typo, None, int, list, dict, bool).
+    # Fail-closed to ask: emit the ask shape with a reason naming the unknown verb.
+    # repr(action) escapes injection attempts in attacker-controlled policy.json.
+    sys.stderr.write(
+        f"policy_gate: unrecognized action {action!r} reached _decision_json "
+        f"(level={level}, tool={tool_name!r}); defaulting to ask\n"
+    )
+    label = LEVEL_LABELS.get(level, "Unknown")
+    return json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": (
+                    f"L{level} ({label}): {tool_name} — unrecognized policy action {action!r}, defaulting to ask"
+                ),
+            }
+        }
+    )
 
 
 def main():

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -718,3 +718,72 @@ class TestLoadPolicyValidatesActionsAtLoadTime:
         captured = capsys.readouterr()
         assert "'Allow'" in captured.err
         assert "override tool=Bash" in captured.err
+
+
+class TestMainEndToEndFailClosedOnMissingCanonical:
+    """#278 R3 end-to-end — main() must NOT emit '{}' when canonical config missing.
+
+    Spec: issue #278 R3 — hook stdout contract is non-{} JSON when _resolve
+    raises. Phase 7.5 evaluator surfaced that the v3 fix only guarded
+    _resolve('DEFAULT_POLICY') via _safe_resolve_default; _classify_tool's
+    _resolve('TOOL_LEVELS') raise path bypassed it, propagated to __main__
+    catch-all → '{}'. This test exercises main() end-to-end to lock in the
+    follow-up fix (_safe_resolve helper used in _classify_tool / _classify_mcp_tool).
+    """
+
+    def test_when_canonical_policy_unreachable_main_emits_non_empty_decision(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Spec #278 R3: with canonical config missing AND user policy present,
+        main() must emit a JSON object containing 'permissionDecision' on
+        stdout, NOT the silent-allow '{}'."""
+        # Point canonical config to a uniquely-named non-existent path
+        missing_canonical = tmp_path / "no-such-policy-gate.json"
+        monkeypatch.setenv("POLICY_GATE_CONFIG_PATH", str(missing_canonical))
+
+        # Provide a user policy so _load_policy enters the load path (not None pass-through)
+        plugin_data = tmp_path / "plugin"
+        plugin_data.mkdir()
+        (plugin_data / "audit").mkdir()
+        (plugin_data / "policy.json").write_text(json.dumps({"rules": [], "overrides": []}))
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(plugin_data))
+
+        # Clear LRU caches so the missing-canonical path is exercised this run
+        policy_gate._load_config_cached.cache_clear()
+        policy_gate._load_schema_cached.cache_clear()
+
+        # Drive main() via stdin
+        stdin_input = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo hi"},
+                "session_id": "test",
+            }
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_input))
+
+        policy_gate.main()
+
+        captured = capsys.readouterr()
+        assert captured.out.strip() != "{}", (
+            f"main() must NOT emit silent-allow '{{}}' on missing canonical "
+            f"config (Phase 7.5 evaluator finding for issue #278 R3); "
+            f"got stdout={captured.out!r}"
+        )
+        # Parse the JSON; permissionDecision must be present
+        parsed = json.loads(captured.out.strip())
+        assert "hookSpecificOutput" in parsed, (
+            f"main() stdout should be a hookSpecificOutput JSON, got {parsed!r}"
+        )
+        assert "permissionDecision" in parsed["hookSpecificOutput"], (
+            f"missing permissionDecision in {parsed!r}"
+        )
+        # Under hardcoded fail-closed L4=deny, Bash is denied; under canonical L4=ask,
+        # _safe_resolve fallback empty-dict-default gives L4 (since TOOL_LEVELS={}),
+        # and _safe_resolve_default's hardcoded {4:"deny"} applies via policy.get.
+        assert parsed["hookSpecificOutput"]["permissionDecision"] in ("ask", "deny"), (
+            f"unexpected permissionDecision {parsed['hookSpecificOutput']['permissionDecision']!r}"
+        )
+
+        # Stderr should mention the fail-closed fallback for trace-ability
+        assert "fail-closed" in captured.err

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -10,6 +10,7 @@ import jsonschema
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks"))
+import policy_gate
 from policy_gate import (
     DEFAULT_POLICY,
     _check_overrides,
@@ -587,3 +588,133 @@ class TestLazyLoadPolicy:
         policy_gate._load_config_cached.cache_clear()
         with pytest.raises((jsonschema.ValidationError, RuntimeError)):
             _ = policy_gate.TOOL_LEVELS
+
+
+class TestDecisionJsonFailClosedOnUnrecognizedAction:
+    """#277 R1, R2 — _decision_json must NOT silently emit "{}" on unrecognized actions.
+
+    Spec: issue #277 R1+R2 — four mis-action shapes covered (string typo, unknown
+    verb, empty string, None). Per ai-written-tests.md practice #1, additional
+    boundary cases (int, list, bool) cover the same defect class — JSON-parseable
+    types that escape pure-string validation.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_action",
+        [
+            "Deny",   # capital-D typo
+            "warn",   # unknown verb
+            "",       # empty string
+            None,     # null
+            4,        # integer from policy.json {"action": 4}
+            ["deny"], # list from policy.json {"action": ["deny"]}
+            True,     # boolean from policy.json {"action": true}
+            {"deny": True},  # dict
+        ],
+    )
+    def test_unrecognized_action_emits_ask_json_not_empty_string(self, bad_action):
+        """Spec #277 R1: result must be a JSON object with permissionDecision=ask,
+        NOT the literal '{}' that the harness interprets as silent-allow."""
+        result = policy_gate._decision_json(bad_action, 4, "Bash")
+        assert result != "{}", (
+            f"unrecognized action {bad_action!r} silently allowed via empty-JSON "
+            f"emission — same defect class as issue #277"
+        )
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "ask", (
+            f"unrecognized action {bad_action!r} should fail-closed to ask, "
+            f"not {parsed!r}"
+        )
+        # The unknown-verb reason must surface attacker-controlled bytes via
+        # repr() so prompt-injection via stderr is mitigated.
+        assert "unrecognized" in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+class TestLoadPolicyFailClosedOnResolveRaise:
+    """#278 R1 — _load_policy must NOT raise out when _resolve raises.
+
+    Spec: issue #278 R1+R3 — when _resolve('DEFAULT_POLICY') raises (canonical
+    policy_gate.json missing, corrupted, or schema-invalid), _load_policy must
+    return the hardcoded fail-closed dict instead of letting the raise reach
+    __main__'s except-Exception → silent-allow path.
+    """
+
+    def test_when_canonical_policy_unreachable_returns_hardcoded_failclosed(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Spec #278 R1: monkeypatch _resolve to simulate canonical policy
+        unreachable; _load_policy returns the hardcoded fail-closed dict and
+        emits a warn to stderr; does NOT raise."""
+        # Set up an empty policy.json (triggers the empty-policy fallback path)
+        policy_file = tmp_path / "policy.json"
+        policy_file.write_text(json.dumps({"rules": []}))
+
+        def raising_resolve(name):
+            raise RuntimeError(f"simulated canonical-policy corruption for {name!r}")
+
+        monkeypatch.setattr(policy_gate, "_resolve", raising_resolve)
+
+        result_policy, overrides = policy_gate._load_policy(str(tmp_path))
+
+        # Fail-closed dict is the spec-defined posture, NOT the canonical default.
+        # The literal values are checked against the documented contract (see
+        # _HARDCODED_FAILCLOSED_POLICY definition + plan.md §Hardcoded fail-closed).
+        assert result_policy == {1: "ask", 2: "ask", 3: "ask", 4: "deny", 5: "deny"}, (
+            f"_load_policy on _resolve raise must return _HARDCODED_FAILCLOSED_POLICY, "
+            f"got {result_policy!r}"
+        )
+        assert overrides == []
+        captured = capsys.readouterr()
+        assert "fail-closed" in captured.err
+        assert "#278" in captured.err
+
+
+class TestLoadPolicyValidatesActionsAtLoadTime:
+    """#277 R3 — _load_policy validates action strings against {allow, ask, deny}
+    at load time, on both rules[] and overrides[]. Substitutes 'ask' + stderr warn.
+    """
+
+    def test_unrecognized_rule_action_substituted_to_ask_with_stderr_warn(
+        self, tmp_path, capsys
+    ):
+        """Spec #277 R3 — rules[]: unknown action verb substituted to ask."""
+        policy_file = tmp_path / "policy.json"
+        policy_file.write_text(json.dumps({"rules": [{"level": "L4", "action": "Deny"}]}))
+
+        result_policy, _ = policy_gate._load_policy(str(tmp_path))
+
+        assert result_policy[4] == "ask", (
+            f"unknown rule action 'Deny' should be substituted to 'ask', got {result_policy[4]!r}"
+        )
+        captured = capsys.readouterr()
+        assert "'Deny'" in captured.err
+        assert "rule level=L4" in captured.err
+
+    def test_unrecognized_override_action_substituted_to_ask(self, tmp_path, capsys):
+        """Spec #277 R3 — overrides[]: unknown action verb substituted at load time.
+
+        Closes the override-action-injection bypass that reviewer-flagged: a
+        policy.json with overrides[].action='Allow' (capital A) or any non-canonical
+        verb must NOT reach _decision_json with a fail-permissive value.
+        """
+        policy_file = tmp_path / "policy.json"
+        policy_file.write_text(
+            json.dumps(
+                {
+                    "rules": [{"level": "L4", "action": "ask"}],
+                    "overrides": [
+                        {"tool": "Bash", "path_pattern": "*", "action": "Allow"}
+                    ],
+                }
+            )
+        )
+
+        _, overrides = policy_gate._load_policy(str(tmp_path))
+
+        assert overrides[0]["action"] == "ask", (
+            f"override action 'Allow' should be substituted to 'ask' at load time, "
+            f"got {overrides[0]['action']!r}"
+        )
+        captured = capsys.readouterr()
+        assert "'Allow'" in captured.err
+        assert "override tool=Bash" in captured.err

--- a/tests/test_policy_gate.py
+++ b/tests/test_policy_gate.py
@@ -507,20 +507,60 @@ class TestLazyLoadPolicy:
     """Cover the PEP 562 lazy-load path for the 5 JSON-derived constants."""
 
     def test_config_missing_raises_runtime_error(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ):
-        """When policy_gate.json is missing, attribute access raises
-        RuntimeError pointing at the config file."""
+        """When policy_gate.json is missing, attribute access via the PEP 562
+        facade returns the per-name fail-closed default and emits a stderr
+        warning — does NOT raise (was the #278 follow-up CRITICAL closed in
+        Phase 8.5: prior behavior was unguarded propagation to __main__ →
+        silent allow)."""
         import policy_gate
 
         monkeypatch.setenv("POLICY_GATE_CONFIG_PATH", str(tmp_path / "absent.json"))
         policy_gate._load_config_cached.cache_clear()
         try:
-            with pytest.raises(
-                RuntimeError,
-                match=r"policy_gate\.json missing at .* — see hooks/policy_gate\.json",
-            ):
-                _ = policy_gate.TOOL_LEVELS
+            # __getattr__ now routes through _safe_resolve with per-name default
+            value = policy_gate.TOOL_LEVELS
+            assert value == {}, (
+                f"missing canonical config should fail-closed to empty dict for "
+                f"TOOL_LEVELS, got {value!r}"
+            )
+            err = capsys.readouterr().err
+            assert "TOOL_LEVELS" in err
+            assert "fail-closed" in err
+        finally:
+            policy_gate._load_config_cached.cache_clear()
+
+    def test_pep562_getattr_fail_closed_per_lazy_name(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Phase 8.5 R2 CRITICAL: PEP 562 __getattr__ must NOT bypass _safe_resolve.
+        Every lazy name returns its per-name fail-closed default on missing canonical
+        config (DEFAULT_POLICY → hardcoded fail-closed dict, others → empty container)."""
+        import policy_gate
+
+        monkeypatch.setenv("POLICY_GATE_CONFIG_PATH", str(tmp_path / "absent.json"))
+        policy_gate._load_config_cached.cache_clear()
+        try:
+            assert policy_gate.TOOL_LEVELS == {}
+            assert policy_gate.L5_BASH_PATTERNS == []
+            assert policy_gate._MCP_L1_PREFIXES == ()
+            assert policy_gate._MCP_L4_VERBS == frozenset()
+            # DEFAULT_POLICY is the only lazy name whose default is the hardcoded
+            # fail-closed dict (not an empty container).
+            assert policy_gate.DEFAULT_POLICY == {
+                1: "ask", 2: "ask", 3: "ask", 4: "deny", 5: "deny",
+            }
+            err = capsys.readouterr().err
+            for name in ("TOOL_LEVELS", "L5_BASH_PATTERNS", "_MCP_L1_PREFIXES",
+                         "_MCP_L4_VERBS", "DEFAULT_POLICY"):
+                assert name in err, f"stderr missing fail-closed trace for {name}"
         finally:
             policy_gate._load_config_cached.cache_clear()
 
@@ -575,10 +615,16 @@ class TestLazyLoadPolicy:
         policy_gate._load_config_cached.cache_clear()
         assert policy_gate.TOOL_LEVELS == {"Custom": 1}
 
-    def test_malformed_json_raises_validation_error(
-        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    def test_malformed_json_fail_closed_to_default(
+        self,
+        tmp_path: pathlib.Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ):
-        """A schema-mismatched JSON raises jsonschema.ValidationError on access."""
+        """A schema-mismatched canonical config makes the PEP 562 facade
+        fail-closed to the per-name default (Phase 8.5 R2 CRITICAL closed:
+        __getattr__ used to propagate jsonschema.ValidationError / RuntimeError
+        to __main__ → silent allow; now routes through _safe_resolve)."""
         import policy_gate
 
         bad_config = {"tool_levels": "not-a-dict"}
@@ -586,8 +632,12 @@ class TestLazyLoadPolicy:
         config_file.write_text(json.dumps(bad_config))
         monkeypatch.setenv("POLICY_GATE_CONFIG_PATH", str(config_file))
         policy_gate._load_config_cached.cache_clear()
-        with pytest.raises((jsonschema.ValidationError, RuntimeError)):
-            _ = policy_gate.TOOL_LEVELS
+        # No raise — fail-closed default returned, stderr names the failure
+        value = policy_gate.TOOL_LEVELS
+        assert value == {}
+        err = capsys.readouterr().err
+        assert "TOOL_LEVELS" in err
+        assert "fail-closed" in err
 
 
 class TestDecisionJsonFailClosedOnUnrecognizedAction:


### PR DESCRIPTION
#277: _decision_json now emits ask JSON (fail-closed) on any action not in
{allow, ask, deny}, including non-string types (int, list, dict, bool, None)
that JSON-parseable policy.json could inject. _load_policy validates action
strings on both rules[] and overrides[] at load time via _validated_action
helper, substituting 'ask' + stderr warn for any unrecognized verb.

#278: _safe_resolve_default helper wraps _resolve('DEFAULT_POLICY') with
typed exception tuple (RuntimeError, FileNotFoundError, JSONDecodeError) +
defense-in-depth except-Exception. On any raise, returns the hardcoded
_HARDCODED_FAILCLOSED_POLICY = {1:'ask', 2:'ask', 3:'ask', 4:'deny',
5:'deny'} -- intentionally STRICTER than the canonical default_policy in
policy_gate.json. The duplication is the defense for #278; do not refactor
into a recursive _resolve dependency.

Closes #277
Closes #278

Co-Authored-By: Claude <noreply@anthropic.com>
