### PR TITLE
feat(eval-cases): add D5 apply round-trip eval case (#131)

### DIFF
--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -224,3 +224,41 @@ Expected analytics behavior:
 - C18-3: Convergence verdict is "Not converged" — `SP-2` differs between reports and is in the deterministic subset (NARRATIVE_PARENT).
 - C18-4: Grade variance for Safety reported as 1 (C→B).
 - C18-5: If both differing finding_ids were advisory (e.g. `WS-1`, `RF-1`), verdict would be "Converged" under the post-#71 scoped policy. View 4 may still report "Not converged" until the analytics scope filter ships in #72 — see the banner in `skills/review-analytics/SKILL.md` View 4.
+
+## Case 19 — D5 Apply Round-Trip
+
+YAML: [`case_15_apply_round_trip.yaml`](../tests/eval_cases/case_15_apply_round_trip.yaml)
+
+defects:
+- {item: SP-2b, dim: Safety, sev: High, desc: "Write in allowed-tools without disable-model-invocation gate"}
+- {item: META-2, dim: Metadata, sev: Medium, desc: "Description lacks do-not-use exclusion phrase"}
+
+Fixture: `tests/fixtures/eval/case_15_apply_round_trip.SKILL.md` — a known-bad skill
+with exactly two deterministic-subset findings of known impact and known mechanical
+fixes. The fixture is otherwise structurally clean (all other binary rubric items are
+PASS or NA) so that a correctly-applied fix produces zero new Medium/High findings on
+re-review.
+
+Sprint contract:
+- **C15-1 (zero remaining original finding_ids):** After `/apply-skill-review-findings`
+  fixes SP-2b and META-2, a re-review produces zero remaining instances of the original
+  finding_ids (`SP-2b:...:Safety/v1` and `META-2:...:Metadata/v1`).
+- **C15-2 (no new Medium/High findings introduced):** Re-review after apply introduces
+  no new Medium or High findings — since the fixture is otherwise clean, any new
+  Medium/High would be a regression introduced by the fix itself.
+- **C15-3 (≤1-letter dimension grade change):** Dimension grade change after apply is
+  at most one letter in any single dimension, confirming the fix does not destabilise
+  unrelated grades.
+- **C15-4 (regression signal):** If a re-review still flags SP-2b or META-2, or
+  introduces a new High finding, the apply-findings skill failed to converge — this
+  signals a regression in the apply pipeline.
+
+Mechanical fixes:
+- **SP-2b:** Add `disable-model-invocation: true` to the fixture's frontmatter.
+- **META-2:** Append a `do not use` exclusion clause to the description, e.g.
+  "Do not use for read-only audits."
+
+This case is the first to exercise the full D5 round-trip. It is a `kind: detection`
+YAML case under `tests/eval_cases/` (not a narrative-only case) and is replayed
+programmatically by `tests/test_eval_cases.py`. The live review → apply → re-review
+loop is driven by `/run-eval-cases`.

--- a/tests/eval_cases/case_15_apply_round_trip.yaml
+++ b/tests/eval_cases/case_15_apply_round_trip.yaml
@@ -1,0 +1,53 @@
+id: case-15-apply-round-trip
+kind: detection
+description: D5 Apply Round-Trip — pre-apply review state with two deterministic-subset findings (SP-2b, META-2); exercises the review → apply-findings → re-review convergence cycle.
+target_skill: review-skill
+artifacts:
+  primary: tests/fixtures/eval/case_15_apply_round_trip.SKILL.md
+findings_fixture: tests/fixtures/eval/case_15_findings.json
+defects:
+  - { item: SP-2b, dim: Safety,    sev: High,   desc: "Write in allowed-tools without disable-model-invocation gate" }
+  - { item: META-2, dim: Metadata, sev: Medium,  desc: "Description lacks do-not-use exclusion phrase" }
+sprint_contract:
+  - id: C15-1
+    description: "After apply-findings fixes SP-2b and META-2, a re-review produces zero remaining instances of the original finding_ids (SP-2b:...:Safety/v1 and META-2:...:Metadata/v1)."
+  - id: C15-2
+    description: "Re-review after apply introduces no new Medium or High findings — the fixture is otherwise clean so any new Medium/High is a regression introduced by the fix."
+  - id: C15-3
+    description: "Dimension grade change after apply is ≤1 letter in any single dimension (accounts for boundary effects and confirms the fix does not destabilise unrelated grades)."
+  - id: C15-4
+    description: "Regression signal: if a re-review still flags SP-2b or META-2, or introduces a new High finding, the apply-findings skill failed to converge — this signals a regression in the apply pipeline."
+expected:
+  required_findings:
+    - { item: SP-2b, dim: Safety,   severity: [High, Medium] }
+    - { item: META-2, dim: Metadata, severity: [Medium, High] }
+  forbidden_findings: []
+  field_invariants:
+    - "every High/Medium finding has non-empty evidence"
+    - "every High/Medium finding has non-empty validation"
+    - "every High finding has non-empty current and recommended"
+acceptance:
+  precision: ">= 0.5"
+  recall:    ">= 0.5"
+execution:
+  dispatch:
+    command: /review-skill
+    target_arg: tests/fixtures/eval/case_15_apply_round_trip.SKILL.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  artifact: tests/fixtures/eval/case_15_apply_round_trip.SKILL.md
+  reviewer_behavior: skills/review-skill/SKILL.md
+notes: |
+  PRE-APPLY review state. Two deterministic-subset defects:
+    SP-2b (Safety/High): Write present in allowed-tools without disable-model-invocation: true.
+    META-2 (Metadata/Medium): description lacks a do-not-use/not-for/skip-when exclusion phrase.
+  Fixes:
+    SP-2b: add `disable-model-invocation: true` to frontmatter.
+    META-2: append exclusion clause to description, e.g. "Do not use for read-only audits."
+  The fixture is otherwise structurally clean so that a correctly-applied fix
+  produces zero new Medium/High findings on re-review. The sprint contract's
+  regression signal (C15-4) fires if the re-review still surfaces these items
+  or introduces a new High finding, indicating the apply pipeline did not converge.

--- a/tests/fixtures/eval/case_15_apply_round_trip.SKILL.md
+++ b/tests/fixtures/eval/case_15_apply_round_trip.SKILL.md
@@ -1,0 +1,55 @@
+---
+name: case-15-apply-round-trip-fixture
+description: Reviews configuration files and updates settings in the target directory.
+allowed-tools: Read, Write, Glob
+---
+
+# Case 15 Apply Round-Trip Fixture
+
+A synthetic skill for the D5 apply round-trip eval case. It intentionally
+carries two deterministic-subset defects with known mechanical fixes:
+
+1. **SP-2b (Safety / High)** — `Write` is present in `allowed-tools` without
+   a `disable-model-invocation: true` gate or an explicit binding clause in the
+   body. Fix: add `disable-model-invocation: true` to frontmatter.
+
+2. **META-2 (Metadata / Medium)** — The `description` field lacks a
+   `do not use` / `not for` / `skip when` exclusion phrase. Fix: append
+   "Do not use for read-only audits." to the description.
+
+All other rubric dimensions are intentionally clean so that no stray
+Medium/High findings inflate the "no new Medium/High" re-review check.
+
+## Workflow
+
+### Step 1 — Locate configuration files
+
+Use Glob to find all `*.yaml` configuration files under the target directory.
+Skip any file whose path contains `.ssh` or `.env`.
+
+### Step 2 — Read and validate each file
+
+For each file found in Step 1, use Read to load its contents and verify the
+required keys are present. Stop with an error message if a file cannot be read.
+
+### Step 3 — Apply updates
+
+For each configuration file that requires a change, use Write to apply the
+update in the target directory.
+
+### Step 4 — Summarise
+
+Produce a Markdown summary listing every file updated and its new setting value.
+Output a final status line indicating the number of files processed.
+
+## Completion
+
+Output the final Markdown summary after all configuration files have been
+processed (updated or confirmed unchanged).
+
+## Error Handling
+
+If Write fails or the target directory is absent, escalate to the user:
+stop with a structured error message listing the affected paths before
+proceeding to Step 4. The workflow produces a partial result with
+`status: partial` when some files succeed and others fail.

--- a/tests/fixtures/eval/case_15_findings.json
+++ b/tests/fixtures/eval/case_15_findings.json
@@ -1,0 +1,41 @@
+{
+  "generated_by": "merge_findings",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-15-apply-round-trip",
+  "artifact_path": "tests/fixtures/eval/case_15_apply_round_trip.SKILL.md",
+  "artifact_type": "skill",
+  "findings": [
+    {
+      "id": "SP-2b:tests/fixtures/eval/case_15_apply_round_trip.SKILL.md:Safety/v1",
+      "checklist_item": "SP-2b",
+      "dimension": "Safety",
+      "severity": "High",
+      "evidence": "line 4; match='Write' present in allowed-tools without disable-model-invocation: true",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/eval/case_15_apply_round_trip.SKILL.md",
+      "line_range": "4",
+      "why": "Binary rubric item SP-2b FAIL per scripts/rubric_binary_evaluator.py. Write-class tools require an explicit disable-model-invocation gate.",
+      "validation": "Re-run scripts/rubric_binary_evaluator.py on the artifact and confirm SP-2b verdict PASS.",
+      "current": "allowed-tools: Read, Write, Glob",
+      "recommended": "allowed-tools: Read, Write, Glob\ndisable-model-invocation: true",
+      "perspective": "binary-evaluator"
+    },
+    {
+      "id": "META-2:tests/fixtures/eval/case_15_apply_round_trip.SKILL.md:Metadata/v1",
+      "checklist_item": "META-2",
+      "dimension": "Metadata",
+      "severity": "Medium",
+      "evidence": "line 3; match='Reviews configuration files and updates settings in the target directory.' — description lacks a do-not-use / not-for / skip-when exclusion phrase.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/eval/case_15_apply_round_trip.SKILL.md",
+      "line_range": "3",
+      "why": "Binary rubric item META-2 FAIL: description does not carry an exclusion phrase that tells the routing layer when NOT to invoke this skill.",
+      "validation": "Re-run scripts/rubric_binary_evaluator.py and confirm META-2 verdict PASS.",
+      "perspective": "binary-evaluator"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #131 (D5: Apply round-trip eval case). Adds a new eval case exercising the review → apply-findings → re-review convergence cycle, which was documented as a CLAUDE.md principle but had no eval-corpus coverage.

Four files (3 new, 1 edit):
- `tests/eval_cases/case_15_apply_round_trip.yaml` — `kind: detection` case modeling the pre-apply review state; sprint-contract encodes the three round-trip clauses (zero remaining original finding_ids, no new Medium/High, ≤1-letter grade change) + regression signal.
- `tests/fixtures/eval/case_15_apply_round_trip.SKILL.md` — known-bad fixture skill with two deterministic-subset defects (SP-2b Safety/High, META-2 Metadata/Medium), each with a mechanical fix so the round-trip converges.
- `tests/fixtures/eval/case_15_findings.json` — synthesized pre-apply findings.
- `docs/review-eval-cases.md` — new "Case 19 — D5 Apply Round-Trip" narrative section.

## Verification

- `make validate` — 1099 passed (+6), 2 skipped, exit 0
- `pytest -k case_15` — 6 passed
- Deterministic-subset gate (P-AC1d): both fixture `checklist_item`s (`SP-2b`, `META-2`) ∈ `BINARY_ITEM_IDS` → True
- Severity gate (P-AC1e): both findings ∈ {Medium, High} → True (forecloses a degenerate Low/Low fixture)
- `/run-eval-cases` discovers the case (glob + 6 collected test node IDs)

## Design notes

- The live review→apply→re-review loop is `/run-eval-cases`-driven (LLM), not pytest-replayed — consistent with how `behavior_*` cases work. pytest validates the YAML schema + pre-apply fixture; the round-trip contract is the `sprint_contract[]` + regression signal.
- NOT a harness-evolution path (`tests/` + `docs/review-eval-cases.md`), so the AHE-class 2-round R2 review minimum does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)