### PR TITLE
docs(review-claude-config): clarify 250-char limit is team policy not platform constraint (#9)

### DIFF
--- a/skills/review-claude-config/references/agent-description-convention.md
+++ b/skills/review-claude-config/references/agent-description-convention.md
@@ -19,10 +19,14 @@ The first sentence of any agent description MUST start with `Use this when …` 
 
 ## 2. Cluster-Density-Aware Length `[E]`
 
-No hard character cap below Anthropic's 1024-char absolute ceiling. Length scales
-with the number of competing primitives in the same trigger cluster — more
-competition needs more disambiguation tokens. A single-agent repo may succeed with
-40 chars; a 10-agent plugin requires 150–300 chars to route reliably.
+No *platform* character cap applies below Anthropic's 1024-char absolute ceiling.
+Separately, the team applies a ≤250-char conciseness standard: a review flagging a
+description >250 chars cites that team standard (`Repo default`, Medium), NOT a
+platform error — 251–1024 chars are platform-valid but above team standard.
+Length otherwise scales with the number of competing primitives in the same trigger
+cluster — more competition needs more disambiguation tokens. A single-agent repo
+may succeed with 40 chars; a 10-agent plugin requires 150–300 chars to route
+reliably.
 
 Reference: Microsoft 775-tool catalog — collision probability rises sharply when
 descriptions share ≥2 trigger tokens across ≥5 siblings.

--- a/skills/review-claude-config/references/skill-description-convention.md
+++ b/skills/review-claude-config/references/skill-description-convention.md
@@ -19,9 +19,12 @@ The first sentence of any skill description MUST start with `Use this when …` 
 
 ## 2. Cluster-Density-Aware Length `[E]`
 
-No hard character cap below Anthropic's 1024-char absolute ceiling. Length scales
-with the number of competing skills in the same plugin — more siblings in the same
-trigger cluster requires more disambiguation tokens.
+No *platform* character cap applies below Anthropic's 1024-char absolute ceiling.
+Separately, the team applies a ≤250-char conciseness standard: a review flagging a
+description >250 chars cites that team standard (`Repo default`, Medium), NOT a
+platform error — 251–1024 chars are platform-valid but above team standard.
+Length otherwise scales with the number of competing skills in the same plugin —
+more siblings in the same trigger cluster requires more disambiguation tokens.
 
 Reference: Microsoft 775-tool catalog — collision probability rises sharply when
 descriptions share ≥2 trigger tokens across ≥5 siblings in the same plugin.


### PR DESCRIPTION
## Summary

Closes #9. Both description-convention reference files stated only "No hard character cap below Anthropic's 1024-char absolute ceiling" — which reads as "anything ≤1024 is fine" and gives an outside-team author flagged for a 400-char description no way to tell a team-standard flag from a platform error.

Reconciles §2 in both `agent-description-convention.md` and `skill-description-convention.md` to distinguish:
- **Platform ceiling**: 1,024 chars (Claude Code hard limit).
- **Team conciseness standard**: ≤250 chars — a `>250` review flag cites this team standard (`Repo default`, Medium), NOT a platform error; 251–1024 chars are platform-valid but above team standard.

The existing cluster-density length-scaling guidance is preserved.

## Scope notes

- `scoring-rubric.md` is NOT edited (Hard Constraint 6 freeze) — and verified to be the wrong target anyway: the ≤250 flag is produced by `scripts/validate_description_graph.py` (`make validate-descriptions`) and defined in `research/multi-primitive-dependencies/multi-primitive-dependency-integrity.md`, not the rubric.
- **Out-of-scope follow-up**: the convention files are authoring-time docs, not the triage-time flag-output surface. Making `validate_description_graph.py`'s flag message reference this distinction would close the loop at the flag site — a separate enhancement beyond this docs clarification.

## Verification

- `make validate` — 1099 passed, exit 0 (token budgets: agent 727/800, skill 785/800 — both pass)
- Both files contain `250` + `1,024` + the team-standard framing
- Diff touches only the two convention files

🤖 Generated with [Claude Code](https://claude.com/claude-code)