### PR TITLE
feat(eval-cases): add D8 analytics regression eval case (#134)

### DIFF
--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -262,3 +262,32 @@ This case is the first to exercise the full D5 round-trip. It is a `kind: detect
 YAML case under `tests/eval_cases/` (not a narrative-only case) and is replayed
 programmatically by `tests/test_eval_cases.py`. The live review → apply → re-review
 loop is driven by `/run-eval-cases`.
+
+## Case 20 — D8 Analytics Regression
+
+YAML: [`case_16_analytics_regression.yaml`](../tests/eval_cases/case_16_analytics_regression.yaml)
+
+defects: N/A (tests analytics regression detection, not finding detection)
+
+Fixture: `tests/fixtures/analytics-regression/` — three timestamped review reports
+for the same artifact (`type: skill`, `path: skills/test-safety-skill/SKILL.md`,
+`name: test-safety-skill`) with dates 2026-01-01, 2026-02-01, and 2026-03-01. The
+`safety` dimension drops B→C→D (score 82→68→55) across the three reports, while all
+other dimensions remain stable at B.
+
+Sprint contract:
+- **C16-1 (regression flagged with correct dimension):** `/review-analytics` surfaces
+  the `safety` dimension as the dropping axis in the regression report.
+- **C16-2 (trajectory direction = Regressing):** The artifact's overall trajectory is
+  classified as Regressing or decline — not Stable or Improving.
+- **C16-3 (regression signal):** Trajectory drop goes unflagged OR direction is
+  inverted (Stable/Improving reported instead of Regressing) — signals a regression
+  in the analytics detection logic.
+
+Regression signal: if `/review-analytics` fails to flag the safety dimension drop or
+classifies the trajectory as Stable/Improving, the grade-step (C→D) and score-drop
+(≥5 points: 68→55) classifier branches have both been bypassed.
+
+This case exercises the analytics trajectory-detection path defined in
+`skills/review-analytics/SKILL.md` §4 "Compute trajectories" (Regressing predicate:
+latest grade lower than previous report OR score dropped by ≥5).

--- a/tests/eval_cases/case_16_analytics_regression.yaml
+++ b/tests/eval_cases/case_16_analytics_regression.yaml
@@ -1,0 +1,35 @@
+id: case-16-analytics-regression
+kind: behavior_analytics
+description: Analytics regression detection — grade trajectory drops B→C→D on the safety dimension across three reports for the same artifact.
+target_skill: review-analytics
+artifacts:
+  report_1: tests/fixtures/analytics-regression/test-safety-skill-2026-01-01.md
+  report_2: tests/fixtures/analytics-regression/test-safety-skill-2026-02-01.md
+  report_3: tests/fixtures/analytics-regression/test-safety-skill-2026-03-01.md
+defects: N/A
+sprint_contract:
+  - id: C16-1
+    description: "Regression is flagged with the correct dimension (safety — the dropping axis)."
+  - id: C16-2
+    description: "Trajectory direction is Regressing or decline (not Stable or Improving)."
+  - id: C16-3
+    description: "Regression signal: trajectory drop goes unflagged OR direction is inverted (Stable/Improving reported instead of Regressing)."
+acceptance: null
+execution:
+  dispatch:
+    command: /review-analytics
+    target_arg: ".claude/eval-temp/"
+    setup: "stage report_1 + report_2 + report_3 under target_arg before dispatch"
+  timeout_seconds: 60
+fix_target:
+  reviewer_behavior: skills/review-analytics/SKILL.md
+notes: |
+  Behavior case — exercises analytics regression detection. The three
+  reports describe the same artifact (name=test-safety-skill,
+  path=skills/test-safety-skill/SKILL.md) across three timestamps.
+  The safety dimension drops B→C→D (score 82→68→55) while all other
+  dimensions remain stable at B. The /review-analytics skill must
+  classify the artifact's overall trajectory as Regressing and surface
+  the safety dimension as the dropping axis.
+  No findings.json contract — the assertion target is the analytics
+  report's narrative output, evaluated by /run-eval-cases.

--- a/tests/fixtures/analytics-regression/test-safety-skill-2026-01-01.md
+++ b/tests/fixtures/analytics-regression/test-safety-skill-2026-01-01.md
@@ -1,0 +1,19 @@
+---
+generated_by: review-skill
+schema_version: "1"
+date: "2026-01-01"
+type: skill
+path: skills/test-safety-skill/SKILL.md
+name: test-safety-skill
+summary:
+  overall: B
+  score: 82
+  clarity: B
+  completeness: B
+  prompt_engineering: B
+  context_engineering: B
+  goal_alignment: B
+  safety: B
+  metadata: B
+findings: []
+---

--- a/tests/fixtures/analytics-regression/test-safety-skill-2026-02-01.md
+++ b/tests/fixtures/analytics-regression/test-safety-skill-2026-02-01.md
@@ -1,0 +1,19 @@
+---
+generated_by: review-skill
+schema_version: "1"
+date: "2026-02-01"
+type: skill
+path: skills/test-safety-skill/SKILL.md
+name: test-safety-skill
+summary:
+  overall: C
+  score: 68
+  clarity: B
+  completeness: B
+  prompt_engineering: B
+  context_engineering: B
+  goal_alignment: B
+  safety: C
+  metadata: B
+findings: []
+---

--- a/tests/fixtures/analytics-regression/test-safety-skill-2026-03-01.md
+++ b/tests/fixtures/analytics-regression/test-safety-skill-2026-03-01.md
@@ -1,0 +1,19 @@
+---
+generated_by: review-skill
+schema_version: "1"
+date: "2026-03-01"
+type: skill
+path: skills/test-safety-skill/SKILL.md
+name: test-safety-skill
+summary:
+  overall: D
+  score: 55
+  clarity: B
+  completeness: B
+  prompt_engineering: B
+  context_engineering: B
+  goal_alignment: B
+  safety: D
+  metadata: B
+findings: []
+---


### PR DESCRIPTION
## Summary

Closes #134 (D8: Analytics regression eval case). Adds a `behavior_analytics` eval case exercising `/review-analytics` grade-trajectory regression detection, which had no fixture.

Files (4 new, 1 edit):
- `tests/fixtures/analytics-regression/test-safety-skill-2026-0{1,2,3}-01.md` — 3 timestamped reports for the same artifact (`skills/test-safety-skill/SKILL.md`) with a deliberate `safety` + `overall` drop B→C→D and a declining overall score 82→68→55 (triggers both classifier branches: grade-step AND score-≥5-drop, per `review-analytics/SKILL.md:78`).
- `tests/eval_cases/case_16_analytics_regression.yaml` — `kind: behavior_analytics` (existing kind, no harness edit), discoverable by `/run-eval-cases`.
- `docs/review-eval-cases.md` — new `## Case 20 — D8 Analytics Regression` section.

## Verification

- `make validate` — 1100 passed (+1), exit 0
- `pytest -k case_16` — 1 passed
- Fixtures: same `type+path`, strict B→C→D safety grades + declining score (verified via `_frontmatter.parse_frontmatter`)
- Discovery: case_16 in glob + collected
- **E2E feature observation** (beyond the discovery AC): the fixture set classifies as Regressing on the safety dimension (grade and score both regress) — confirming the case exercises the path it documents.

## Notes

- `behavior_analytics` cases are `/run-eval-cases`-driven (LLM) by design; pytest does YAML-structural validation only. The ongoing detection guarantee depends on `/run-eval-cases` being run (not in CI) — documented honestly, mitigated by the one-time E2E observation above.
- NOT a harness-evolution path (`tests/` + `docs/review-eval-cases.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)