### PR TITLE
feat(eval-cases): add D9 hook quality eval case (#135)

### DIFF
--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -320,3 +320,35 @@ Sprint contract:
 - **C21-3 (regression signal):** review passes the oversized fixture without a
   token-density-related finding — signals that the reviewer is failing to apply
   signal-density heuristics to oversized primitives
+
+## Case 22 — D9 Hook Quality
+
+(YAML: `tests/eval_cases/case_18_hook_quality.yaml`)
+
+Fixture: `tests/fixtures/hook-bad/` — a synthetic `hooks.json` binding `bad_hook.py`
+to a `PreToolUse` (blocking) event, plus `bad_hook.py` containing three deliberate
+defects that map to known hook checklist items.
+
+defects:
+- {item: HC-7, dim: Safety, sev: High, desc: "Non-zero exit on PreToolUse success path blocks action unconditionally"}
+- {item: SR-1, dim: Safety, sev: High, desc: "Credential (API_TOKEN) read and logged to stdout via print()"}
+- {item: PY-1, dim: Completeness, sev: Medium, desc: "Reads input from sys.argv instead of sys.stdin; event payload is silently dropped"}
+
+The `hooks.json` binds the bad hook to `PreToolUse` (a blocking event) so that HC-7
+is FAIL rather than N/A — HC-7 only applies when the hook is on a blocking event.
+SR-1 uses a credential-read-inside-print pattern (no literal token embedded).
+PY-1 reads from `sys.argv` rather than `sys.stdin`, silently dropping the JSON
+event payload that Claude Code delivers on stdin.
+
+These are **hook-quality findings** from `skills/review-hook/references/hook-evaluation-guide.md`,
+NOT skill binary-evaluator items. The pytest layer validates the findings fixture schema
+and precision/recall internal consistency only. LLM-driven evaluation via `/run-eval-cases`
+is the real assertion for C22-1 and C22-2.
+
+Sprint contract:
+- **C22-1:** `/review-hook` flags ≥3 findings matching the seeded defects (HC-7 exit-code,
+  SR-1 redaction, PY-1 stdin) at expected severity
+- **C22-2:** each seeded defect is flagged (no silent miss)
+- **C22-3 (regression signal):** any seeded defect goes unflagged — signals a regression
+  in hook-quality reviewer coverage for exit-code discipline, credential redaction,
+  or stdin contract

--- a/tests/eval_cases/case_18_hook_quality.yaml
+++ b/tests/eval_cases/case_18_hook_quality.yaml
@@ -1,0 +1,60 @@
+id: case-18-hook-quality
+kind: detection
+description: Hook Quality (D9) — defective hook must surface HC-7/SR-1/PY-1 findings from /review-hook.
+target_skill: review-hook
+artifacts:
+  hooks_json: tests/fixtures/hook-bad/hooks.json
+  bad_hook: tests/fixtures/hook-bad/bad_hook.py
+findings_fixture: tests/fixtures/eval/case_18_findings.json
+defects:
+  - { item: HC-7, dim: Safety,      sev: High,   desc: "Non-zero exit on PreToolUse success path blocks action unconditionally" }
+  - { item: SR-1, dim: Safety,      sev: High,   desc: "Credential (API_TOKEN) read and logged to stdout via print()" }
+  - { item: PY-1, dim: Completeness, sev: Medium, desc: "Reads input from sys.argv instead of sys.stdin; event payload is silently dropped" }
+sprint_contract:
+  - id: C22-1
+    description: "≥3 findings matching the seeded defects (HC-7 exit-code, SR-1 redaction, PY-1 stdin) at expected severity"
+  - id: C22-2
+    description: "each seeded defect flagged (no silent miss)"
+  - id: C22-3
+    description: "regression signal: any seeded defect goes unflagged"
+expected:
+  required_findings:
+    - { item: HC-7, dim: Safety,      severity: [High, Medium] }
+    - { item: SR-1, dim: Safety,      severity: [High, Medium] }
+    - { item: PY-1, dim: Completeness, severity: [Medium, Low] }
+  forbidden_findings: []
+  field_invariants:
+    - "every High/Medium finding has non-empty evidence"
+    - "every High/Medium finding has non-empty validation"
+    - "every High finding has non-empty current and recommended"
+acceptance:
+  precision: ">= 0.5"
+  recall:    ">= 0.5"
+execution:
+  dispatch:
+    command: /review-hook
+    target_arg: tests/fixtures/hook-bad/hooks.json
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  reviewer_behavior: skills/review-hook/SKILL.md
+notes: |
+  Findings are hook-quality items (HC-7, SR-1, PY-1) from the hook evaluation
+  guide (skills/review-hook/references/hook-evaluation-guide.md), NOT skill
+  binary-evaluator items (BINARY_ITEM_IDS). The D5 deterministic-subset predicate
+  does NOT apply — the pytest layer validates only the findings_fixture schema
+  and precision/recall internal consistency. LLM-driven evaluation via
+  /run-eval-cases is the real assertion for C22-1 and C22-2.
+
+  The fixture hooks.json binds bad_hook.py to PreToolUse (a blocking event) so
+  HC-7 is FAIL rather than N/A. SR-1 uses a credential-read-inside-print pattern
+  (no literal token embedded). PY-1 uses sys.argv instead of sys.stdin.
+
+  A stray 4th finding (e.g. PY-8 no top-level handler) is acceptable — it does
+  not break the mechanical gate (precision >= 0.5 with 3 TP + 1 FP = 0.75).
+
+  C22-3 is the regression signal clause: if /review-hook runs on this fixture
+  and any of HC-7, SR-1, or PY-1 goes unflagged, the hook-quality reviewer has
+  regressed. This signal is delivered via /run-eval-cases, not CI.

--- a/tests/fixtures/eval/case_18_findings.json
+++ b/tests/fixtures/eval/case_18_findings.json
@@ -1,0 +1,58 @@
+{
+  "generated_by": "synth-case-18-hook-quality",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-18-hook-quality",
+  "artifact_path": "tests/fixtures/hook-bad/hooks.json",
+  "artifact_type": "hook",
+  "findings": [
+    {
+      "id": "HC-7:tests/fixtures/hook-bad/bad_hook.py:Safety/v1",
+      "checklist_item": "HC-7",
+      "dimension": "Safety",
+      "severity": "High",
+      "evidence": "bad_hook.py line 26: `sys.exit(1)` is on the success path — after no error condition, the hook exits non-zero, which causes PreToolUse to block the action unconditionally.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/hook-bad/bad_hook.py",
+      "line_range": "26",
+      "why": "HC-7 FAIL: PreToolUse is a blocking event. A non-zero exit code blocks the tool call. The hook has no error condition on the success path yet exits 1, so every tool call is erroneously blocked.",
+      "validation": "Inspect bad_hook.py and confirm the success path exits 0 (allow) and only genuine error conditions exit non-zero.",
+      "current": "sys.exit(1)  # unconditional, on success path",
+      "recommended": "sys.exit(0)  # allow the action; use sys.exit(1) only when the hook explicitly wants to block",
+      "perspective": "hook-evaluator"
+    },
+    {
+      "id": "SR-1:tests/fixtures/hook-bad/bad_hook.py:Safety/v1",
+      "checklist_item": "SR-1",
+      "dimension": "Safety",
+      "severity": "High",
+      "evidence": "bad_hook.py line 23: `print(os.environ.get(\"API_TOKEN\"))` reads a credential from the environment and logs it to stdout, which Claude Code injects into the conversation context.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/hook-bad/bad_hook.py",
+      "line_range": "23",
+      "why": "SR-1 FAIL: Credentials must never be logged to stdout or stderr. The API_TOKEN value is exposed in the conversation transcript on every hook invocation.",
+      "validation": "Remove all credential reads from stdout/stderr paths. If the token is needed, use it in-memory only (e.g. in a header dict) without printing it.",
+      "current": "print(os.environ.get(\"API_TOKEN\"))",
+      "recommended": "# Do not log credentials. If the token is required, read it into a variable and\n# use it directly without printing:\n# token = os.environ.get(\"API_TOKEN\", \"\")\n# headers = {\"Authorization\": f\"Bearer {token}\"}",
+      "perspective": "hook-evaluator"
+    },
+    {
+      "id": "PY-1:tests/fixtures/hook-bad/bad_hook.py:Completeness/v1",
+      "checklist_item": "PY-1",
+      "dimension": "Completeness",
+      "severity": "Medium",
+      "evidence": "bad_hook.py line 20: `tool_name = sys.argv[1] if len(sys.argv) > 1 else \"unknown\"` reads the tool name from argv. Claude Code delivers the hook event payload as JSON on stdin, not as argv arguments.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/hook-bad/bad_hook.py",
+      "line_range": "20",
+      "why": "PY-1 FAIL: Hook scripts receive event data (tool name, parameters, session context) as a JSON object on stdin. Reading from argv silently ignores the event payload, making the hook unable to inspect or act on the actual tool call.",
+      "validation": "Replace argv-based input with `import json; event = json.load(sys.stdin)` and derive the tool name from `event.get('tool_name', 'unknown')`.",
+      "perspective": "hook-evaluator"
+    }
+  ]
+}

--- a/tests/fixtures/hook-bad/bad_hook.py
+++ b/tests/fixtures/hook-bad/bad_hook.py
@@ -1,0 +1,25 @@
+"""Deliberately defective hook script — eval fixture for case 18 (D9 Hook Quality).
+
+Seeded defects:
+  HC-7: exits with sys.exit(1) on the success path (non-zero exit blocks PreToolUse
+        when the hook should have allowed the action).
+  SR-1: logs a credential-read to stdout via print(os.environ.get("API_TOKEN")),
+        exposing any token value present in the environment.
+  PY-1: reads input from sys.argv instead of sys.stdin; hook events provide
+        JSON on stdin, so argv-based input silently drops the event payload.
+
+This script is intentionally non-functional — it exists only as a detection
+fixture. Do NOT register this hook in any real settings.json.
+"""
+
+import os
+import sys
+
+# PY-1: reads from sys.argv instead of sys.stdin
+tool_name = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+
+# SR-1: logs a credential from the environment to stdout
+print(os.environ.get("API_TOKEN"))
+
+# HC-7: exits non-zero on the success path (should exit 0 to allow the action)
+sys.exit(1)

--- a/tests/fixtures/hook-bad/hooks.json
+++ b/tests/fixtures/hook-bad/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Synthetic hooks.json fixture for eval case 18 (D9 Hook Quality). Deliberately defective hook bound to PreToolUse (blocking) so HC-7 applies.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "description": "Bad hook: seeded with HC-7, SR-1, PY-1 defects for /review-hook eval",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 tests/fixtures/hook-bad/bad_hook.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes #135 (D9: Hook quality eval case). Adds a `detection` eval case (target `review-hook`) exercising hook-specific failure modes (exit-code discipline, secret redaction, stdin contract), previously absent from the eval set.

Files (4 new, 1 edit):
- `tests/fixtures/hook-bad/{hooks.json,bad_hook.py}` — a `PreToolUse`-bound hook with 3 deliberate defects: HC-7 (non-zero exit on success — requires a blocking event), SR-1 (credential printed to stdout, no literal token), PY-1 (reads `sys.argv` not `sys.stdin`).
- `tests/fixtures/eval/case_18_findings.json` — 3 findings {HC-7/Safety/High, SR-1/Safety/High, PY-1/Completeness/Medium} with literal schema-enum dimensions.
- `tests/eval_cases/case_18_hook_quality.yaml` — `kind: detection`, defects 1:1, C22-* clauses.
- `docs/review-eval-cases.md` — `## Case 22 — D9 Hook Quality` + YAML cross-reference.

## Verification

- `make validate` — 1112 passed (+6), exit 0
- `pytest -k case_18` — 6 passed (schema + precision/recall + field_invariants)
- Defect signatures present (`sys.argv`, `sys.exit(1)`, credential-print); `PreToolUse` blocking event present (HC-7 applies)
- Discovery: case_18 in glob + collected

## Notes

- HC-7 requires a **blocking** event (exit-2 semantics) — the fixture binds `PreToolUse`, else HC-7 would be NA not FAIL.
- findings.json `dimension` uses literal schema-enum strings (`Completeness`, not the guide's `Compl` abbreviation, which would fail the enum).
- The verbosity/quality findings are hook-evaluation-guide items (not the skill/agent binary evaluator), so no deterministic-subset constraint.
- Detection cases are `/run-eval-cases`-driven (LLM) for live behavior; pytest validates fixture-internal consistency. The non-gating E2E `/review-hook` observation could not run in the build context (plugin-distributed skill not invokable via the Skill tool); ongoing detection is `/run-eval-cases`-driven — documented residual.
- NOT a harness-evolution path (`tests/` + `docs/review-eval-cases.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)