### PR TITLE
feat(eval-cases): add D1 rule 3-dimension eval case (#127)

### DIFF
--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -352,3 +352,35 @@ Sprint contract:
 - **C22-3 (regression signal):** any seeded defect goes unflagged — signals a regression
   in hook-quality reviewer coverage for exit-code discipline, credential redaction,
   or stdin contract
+
+## Case 23 — D1 Rule 3-Dimension Scoring
+
+(YAML: `tests/eval_cases/case_19_rule_three_dim.yaml`)
+
+Fixture: `tests/fixtures/rule-bad/` — a synthetic rule file (`test-fixture-rule.md`)
+describing a request-routing mandate, with three deliberate defects seeded across the
+three dimensions applicable to rules.
+
+defects:
+- {item: CL-2, dim: Clarity, sev: High, desc: "Vague terms 'appropriately' and 'reasonable' admit multiple opposite actions"}
+- {item: CO-2, dim: Completeness, sev: Medium, desc: "No exceptions / when-rule-does-NOT-apply section"}
+- {item: GA-5, dim: Goal Alignment, sev: Medium, desc: "Stated goal ('quickly and effectively') has no constraints enforcing it in the mandate"}
+
+Rules use only **Clarity (30%) / Completeness (30%) / Goal Alignment (40%)**. PE,
+CE, Safety, and Metadata are structurally inapplicable
+(`skills/review-rule/references/rule-evaluation-guide.md` line 11). A correct
+reviewer must score exclusively these three dimensions and must NOT emit grades for
+PE/CE/Safety/Metadata.
+
+These are **rule-evaluation-guide findings** (CL-2, CO-2, GA-5) from
+`skills/review-rule/references/rule-evaluation-guide.md`, NOT skill binary-evaluator
+items. The pytest layer validates the findings fixture schema and precision/recall
+internal consistency only. LLM-driven evaluation via `/run-eval-cases` is the real
+assertion for C23-1 and C23-2.
+
+Sprint contract:
+- **C23-1:** reviewer scores ONLY the 3 applicable dimensions (Clarity/Completeness/Goal
+  Alignment); PE/CE/Safety/Metadata absent or N/A
+- **C23-2:** flags the seeded CL-2/CO-2/GA-5 defects
+- **C23-3 (regression signal):** reviewer emits a 7-dimension grade or misses a seeded
+  defect — signals a regression in the rule-evaluation 3-dimension path

--- a/tests/eval_cases/case_19_rule_three_dim.yaml
+++ b/tests/eval_cases/case_19_rule_three_dim.yaml
@@ -1,0 +1,59 @@
+id: case-19-rule-three-dim
+kind: detection
+description: D1 Rule 3-Dimension Scoring — synthetic rule with CL-2/CO-2/GA-5 defects exercises the Clarity/Completeness/Goal Alignment path of /review-rule.
+target_skill: review-rule
+artifacts:
+  primary: tests/fixtures/rule-bad/test-fixture-rule.md
+findings_fixture: tests/fixtures/eval/case_19_findings.json
+defects:
+  - { item: CL-2, dim: Clarity,         sev: High,   desc: "Vague terms 'appropriately' and 'reasonable' admit multiple opposite actions" }
+  - { item: CO-2, dim: Completeness,    sev: Medium, desc: "No exceptions / when-rule-does-NOT-apply section" }
+  - { item: GA-5, dim: "Goal Alignment", sev: Medium, desc: "Stated goal ('quickly and effectively') has no constraints enforcing it in the mandate" }
+sprint_contract:
+  - id: C23-1
+    description: "reviewer scores ONLY the 3 applicable dimensions (Clarity/Completeness/Goal Alignment); PE/CE/Safety/Metadata absent or N/A"
+  - id: C23-2
+    description: "flags the seeded CL-2/CO-2/GA-5 defects"
+  - id: C23-3
+    description: "regression signal: reviewer emits a 7-dimension grade or misses a seeded defect"
+expected:
+  required_findings:
+    - { item: CL-2, dim: Clarity,         severity: [High, Medium] }
+    - { item: CO-2, dim: Completeness,    severity: [Medium, Low] }
+    - { item: GA-5, dim: "Goal Alignment", severity: [Medium, Low] }
+  forbidden_findings: []
+  field_invariants:
+    - "every High/Medium finding has non-empty evidence"
+    - "every High/Medium finding has non-empty validation"
+    - "every High finding has non-empty current and recommended"
+acceptance:
+  precision: ">= 0.5"
+  recall:    ">= 0.5"
+execution:
+  dispatch:
+    command: /review-rule
+    target_arg: tests/fixtures/rule-bad/test-fixture-rule.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  reviewer_behavior: skills/review-rule/SKILL.md
+notes: |
+  3-dimension scoring path: rules use only Clarity (30%) / Completeness (30%) /
+  Goal Alignment (40%). PE, CE, Safety, and Metadata are structurally inapplicable
+  (rule-evaluation-guide.md line 11). The reviewer must NOT emit scores for the
+  inapplicable dimensions.
+
+  Findings are rule-evaluation-guide items (CL-2, CO-2, GA-5) — NOT skill
+  binary-evaluator items (BINARY_ITEM_IDS). The pytest layer validates only the
+  findings_fixture schema and precision/recall internal consistency. LLM-driven
+  evaluation via /run-eval-cases is the real assertion for C23-1 and C23-2.
+
+  The seeded defects are 1:1 exact with the 3 findings (precision = recall = 1.0
+  fixture-internal). A stray 4th finding (e.g. CL-4 on action verbs) is acceptable
+  — it does not break the gate (precision >= 0.5 with 3 TP + 1 FP = 0.75).
+
+  C23-3 is the regression signal clause: if /review-rule emits a 7-dimension
+  grade on this fixture, or misses any of CL-2/CO-2/GA-5, the 3-dimension path
+  has regressed. Signal is delivered via /run-eval-cases, not CI.

--- a/tests/fixtures/eval/case_19_findings.json
+++ b/tests/fixtures/eval/case_19_findings.json
@@ -1,0 +1,56 @@
+{
+  "generated_by": "synth-case-19-rule-three-dim",
+  "schema_version": "1.0.0",
+  "session_id": "synth-case-19-rule-three-dim",
+  "artifact_path": "tests/fixtures/rule-bad/test-fixture-rule.md",
+  "artifact_type": "rule",
+  "findings": [
+    {
+      "id": "CL-2:tests/fixtures/rule-bad/test-fixture-rule.md:Clarity/v1",
+      "checklist_item": "CL-2",
+      "dimension": "Clarity",
+      "severity": "High",
+      "evidence": "Line 11: 'should be handled appropriately' — 'appropriately' is a vague qualifier that admits multiple opposite actions. Line 13: 'reasonable validation' — 'reasonable' is undefined and implementation-dependent.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/rule-bad/test-fixture-rule.md",
+      "line_range": "11-13",
+      "why": "CL-2 FAIL: Terms like 'appropriately' and 'reasonable' fail the precision test. Two implementers reading 'handle appropriately given the session state' can take opposite actions (e.g. one escalates, one falls back silently). 'Reasonable validation' gives no measurable criterion for what constitutes a valid request.",
+      "validation": "Replace 'appropriately' with a concrete action verb (e.g. 'prompt the user for clarification via AskUserQuestion') and replace 'reasonable validation' with a named check (e.g. 'schema-validate the request payload against the handler contract before dispatching').",
+      "current": "Requests with ambiguous intent should be handled appropriately given the session's current state.\nFor requests involving external services, apply reasonable validation before dispatching.",
+      "recommended": "Requests with ambiguous intent must be surfaced to the user via AskUserQuestion before dispatch.\nFor requests involving external services, validate the request payload against the handler's declared input schema before dispatching.",
+      "perspective": "rule-evaluator"
+    },
+    {
+      "id": "CO-2:tests/fixtures/rule-bad/test-fixture-rule.md:Completeness/v1",
+      "checklist_item": "CO-2",
+      "dimension": "Completeness",
+      "severity": "Medium",
+      "evidence": "The rule has no section or clause stating when it does NOT apply. There is no 'When NOT to apply', 'Exclusions', or 'Suppressors' section. Trivial requests, headless sessions, and direct-user-override cases are not addressed.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/rule-bad/test-fixture-rule.md",
+      "line_range": "1-23",
+      "why": "CO-2 FAIL: A routing rule that applies universally without exceptions will misfire on trivial one-liner requests, session-start status checks, and cases where the user explicitly says 'skip pipeline'. Without stated exceptions, an implementer has no basis to bypass the pipeline on legitimate no-pipeline paths.",
+      "validation": "Add an 'Exclusions' or 'When NOT to apply' section that lists: (1) trivial one-liner changes; (2) questions (no deliverable output); (3) session-start actions; (4) user-explicit 'skip pipeline' directive.",
+      "perspective": "rule-evaluator"
+    },
+    {
+      "id": "GA-5:tests/fixtures/rule-bad/test-fixture-rule.md:Goal Alignment/v1",
+      "checklist_item": "GA-5",
+      "dimension": "Goal Alignment",
+      "severity": "Medium",
+      "evidence": "The stated goal (line 20–21) is 'ensure that user requests are handled quickly and effectively', but the rule contains no constraint on latency or quality of dispatch. The mandate (lines 8–13) only requires routing to 'an appropriate handler' with no success criterion, timeout bound, or fallback when no handler matches.",
+      "primary_focus": true,
+      "owner_conflict": false,
+      "hint_owner": null,
+      "path": "tests/fixtures/rule-bad/test-fixture-rule.md",
+      "line_range": "8-13",
+      "why": "GA-5 FAIL: The goal asserts 'quickly and effectively' but the mandate supplies no constraint that enforces either property. A handler selected by the dispatch pipeline can silently fail or take unbounded time without violating any stated rule constraint. The missing constraints are: (1) a fallback action when no handler matches; (2) a definition of 'effective' dispatch (e.g. the handler must acknowledge the request before the next user turn).",
+      "validation": "Add to the mandate: (1) an explicit fallback clause ('if no handler matches, surface the gap to the user via AskUserQuestion'); (2) a measurable success criterion for dispatch quality.",
+      "perspective": "rule-evaluator"
+    }
+  ]
+}

--- a/tests/fixtures/rule-bad/test-fixture-rule.md
+++ b/tests/fixtures/rule-bad/test-fixture-rule.md
@@ -1,0 +1,30 @@
+# Request Routing
+
+Operational rule for routing user requests to the appropriate handler
+within the session. Loaded for every session in `~/workspace/`.
+
+## Mandate
+
+When a user submits a request, the session must route it to an
+appropriate handler in a timely manner. Handlers are selected based
+on the request's content and context. Requests with ambiguous intent
+should be handled appropriately given the session's current state.
+
+Route all requests through the standard dispatch pipeline. For
+requests involving external services, apply reasonable validation
+before dispatching.
+
+## Examples
+
+| Request type | Action |
+|---|---|
+| Simple question | Answer directly |
+| Code change request | Invoke the relevant code agent |
+| Research request | Invoke the researcher agent |
+| Settings change | Update the relevant config |
+
+## Notes
+
+The goal of this rule is to ensure that user requests are handled
+quickly and effectively. Route to the handler that best fits the
+request type.


### PR DESCRIPTION
## Summary

Closes #127 (D1: Rule-specific eval case). Adds a `detection` eval case (target `review-rule`) exercising the **3-dimension** scoring path (Clarity / Completeness / Goal Alignment — PE/CE/Safety/Metadata structurally inapplicable), previously uncovered.

Files (3 new, 1 edit):
- `tests/fixtures/rule-bad/test-fixture-rule.md` — synthetic rule with 3 defects: vague term (CL-2/Clarity), no exceptions section (CO-2/Completeness), missing goal constraint (GA-5/Goal Alignment). No RFC1918 IPs / home-dir paths (doc-class hook-safe).
- `tests/fixtures/eval/case_19_findings.json` — 3 findings with literal schema-enum dimensions; CL-2 High (current/recommended), CO-2 + GA-5 Medium.
- `tests/eval_cases/case_19_rule_three_dim.yaml` — `kind: detection`, defects 1:1, `required_findings` severity lists widened per the case_18 precedent, C23-* clauses.
- `docs/review-eval-cases.md` — `## Case 23 — D1 Rule 3-Dimension Scoring` + YAML cross-reference.

## Verification

- `make validate` — 1118 passed (+6), exit 0
- `pytest -k case_19` — 6 passed (schema + precision/recall + field_invariants)
- findings dims literal {Clarity, Completeness, Goal Alignment}; items {CL-2, CO-2, GA-5}; defects 1:1
- Discovery: case_19 in glob + collected

## Notes

- review-rule scores ONLY 3 dimensions; the C23-1 clause asserts a 7-dimension grade is a regression signal.
- Detection cases are `/run-eval-cases`-driven (LLM) for live behavior; pytest validates fixture-internal consistency. `/review-rule` is a plugin skill (non-invokable via the Skill tool in the build context); ongoing detection is `/run-eval-cases`-driven — documented residual (accepted whole-eval-suite property).
- NOT a harness-evolution path (`tests/` + `docs/review-eval-cases.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)