### PR TITLE
docs(develop-hooks): document the defer PreToolUse permission decision pattern (#8)

### DIFF
--- a/skills/develop-hooks/SKILL.md
+++ b/skills/develop-hooks/SKILL.md
@@ -28,7 +28,7 @@ Valid hook types (26 events):
 
 | Event | When it fires |
 |-------|--------------|
-| `PreToolUse` | Before a tool call — can allow/deny/rewrite input |
+| `PreToolUse` | Before a tool call — can allow/deny/rewrite input + defer (pause headless session) |
 | `PostToolUse` | After a successful tool call |
 | `PostToolUseFailure` | After a tool call that returned an error |
 | `UserPromptSubmit` | When the user submits a prompt |
@@ -77,7 +77,7 @@ Ask the user for:
 3. **Input fields** — Which `tool_input` fields does the hook inspect (e.g., `file_path`, `command`)? Not applicable to `SessionStart` or `Stop`.
 4. **Output type** — Choose one:
    - `systemMessage` — inject guidance text into Claude's context (PreToolUse)
-   - `permissionDecision` — `"allow"`, `"deny"`, or `"ask"` (PreToolUse); deny takes priority over ask, which takes priority over allow when multiple hooks run
+   - `permissionDecision` — `"allow"`, `"deny"`, `"ask"`, or `"defer"` (v2.1.89+, officially-undocumented — see hook-template.py / anthropics/claude-code#41791) (PreToolUse); deny takes priority over ask, which takes priority over allow when multiple hooks run
    - `updatedInput` — rewrite tool input fields before execution (PreToolUse)
    - `additionalContext` — inject session context (SessionStart)
    - `{}` — no-op or async logging only

--- a/skills/develop-hooks/references/hook-template.py
+++ b/skills/develop-hooks/references/hook-template.py
@@ -55,10 +55,13 @@ PreToolUse — ask user to decide:
     {"permissionDecision": "ask", "userMessage": "reason"}
 
 PreToolUse — defer (pause a headless/CI session at this tool boundary; v2.1.89+,
-REAL but officially-undocumented — tracked anthropics/claude-code#41791; re-verify
-against code.claude.com/docs/en/hooks before relying on the exact field shape):
+REAL but officially-undocumented — tracked anthropics/claude-code#41791. ALL three
+specifics below — the field shape, the resume invocation, and the single-tool-call
+constraint — are undocumented; re-verify each against code.claude.com/docs/en/hooks
+before relying on them):
     {"permissionDecision": "defer"}
-# Resumes via:  claude -p --resume <session-id>
+# Resumes via:  claude -p --resume <session-id>  (session-level headless resume —
+#   distinct from subagent-dispatch resume, which the plain CLI does not support).
 # GOTCHA: only works when Claude makes a SINGLE tool call in the turn —
 #         a multi-tool turn cannot defer one call while leaving the rest unresolved.
 

--- a/skills/develop-hooks/references/hook-template.py
+++ b/skills/develop-hooks/references/hook-template.py
@@ -54,6 +54,14 @@ PreToolUse — allow with rewritten input:
 PreToolUse — ask user to decide:
     {"permissionDecision": "ask", "userMessage": "reason"}
 
+PreToolUse — defer (pause a headless/CI session at this tool boundary; v2.1.89+,
+REAL but officially-undocumented — tracked anthropics/claude-code#41791; re-verify
+against code.claude.com/docs/en/hooks before relying on the exact field shape):
+    {"permissionDecision": "defer"}
+# Resumes via:  claude -p --resume <session-id>
+# GOTCHA: only works when Claude makes a SINGLE tool call in the turn —
+#         a multi-tool turn cannot defer one call while leaving the rest unresolved.
+
 SessionStart — inject session context:
     {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
 


### PR DESCRIPTION
## Summary

Closes #8. Documents the `permissionDecision: "defer"` PreToolUse pattern in the `develop-hooks` skill.

**Capability provenance (verified this session via `claude-code-guide`):** `defer` is REAL in Claude Code v2.1.89+ but is NOT in the official public hooks docs (which list only allow/deny/ask) — tracked as a docs gap in [anthropics/claude-code#41791](https://github.com/anthropics/claude-code/issues/41791). The doc content is labeled accordingly (v2.1.89+, officially-undocumented) and does not present `defer` as a stable/official API.

Files (2):
- `skills/develop-hooks/references/hook-template.py` — adds a `defer` PreToolUse example after deny/allow/ask, showing only the verified `{"permissionDecision": "defer"}` (no fabricated field shape), the `claude -p --resume <session-id>` resume note, and the single-tool-call constraint gotcha.
- `skills/develop-hooks/SKILL.md` — reconciles the `permissionDecision` enumeration (line 80) and the PreToolUse capability-table row (line 31) to include `defer`, so the skill is not internally contradictory (previously a closed allow/deny/ask list).

## Verification

- `make validate` — 1118 passed, exit 0 (ruff scopes `hooks/ scripts/`; the skill template/SKILL.md are not linted)
- Evidence label present + conjunctive (v2.1.89 AND undocumented/#41791); resume note + single-tool-call gotcha present
- No fabricated field shape beyond the verified `permissionDecision: "defer"` value
- Diff touches exactly the 2 files

## Notes

- AHE-class (`skills/develop-hooks/`) — reviewed under the 2-round R2 harness-evolution minimum.
- The GitHub `#41791` reference is an upstream public-URL provenance ref (per the capability-claims rule), not an internal tracker ID.
- Staleness caveat: the `.py` template carries an inline "re-verify against the official docs before relying on the exact field shape" note, since `defer` is changeable-and-undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)