### PR TITLE
feat(eval-cases): add D6 stub-primitive behavior_review case (#132)

### DIFF
--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -437,19 +437,20 @@ D6 label. This case guards against reviewer hallucination: confidently grading a
 near-empty primitive on content-dependent dimensions where there is no substantive
 body to assess. Unlike `detection`/`clean` cases, it asserts a property of review
 *process* behavior. The pytest layer (`tests/test_eval_cases.py`) validates only the
-YAML structure; the behavioral assertion (C21-1/C21-2) is LLM-driven and runs only
+YAML structure; the behavioral assertion (C25-1/C25-2) is LLM-driven and runs only
 via `/run-eval-cases`, which is non-deterministic — there is no programmatic replay
 path for it.
 
-Sprint contract:
-- **C21-1 (correct behavior):** EITHER the certificate raises an explicit stub /
+Sprint contract (IDs use the `C25-*` prefix matching this doc Case 25 — the YAML-stem
+prefix `C21-*` is already owned by Case 21 / `case_17_oversized_primitive.yaml`):
+- **C25-1 (correct behavior):** EITHER the certificate raises an explicit stub /
   insufficient-content finding, OR **no** content-dependent dimension (Completeness,
   Prompt Engineering, Context Engineering, Goal Alignment) is awarded a confident high
   grade (A or B).
-- **C21-2 (regression signal):** no stub/insufficiency finding is raised AND at least
+- **C25-2 (regression signal):** no stub/insufficiency finding is raised AND at least
   one content-dependent dimension is awarded a confident high grade (A or B) — the
   reviewer confidently grades a no-content dimension as if the stub were a complete
-  primitive (hallucination). C21-1 and C21-2 are exact complements: every review output
+  primitive (hallucination). C25-1 and C25-2 are exact complements: every review output
   lands in exactly one, with no quantifier dead zone.
 
 Regression signal: reviewer returns A or B on any of Completeness, Prompt Engineering,

--- a/docs/review-eval-cases.md
+++ b/docs/review-eval-cases.md
@@ -20,7 +20,7 @@ Cases C6–C18 below remain as narrative specifications — they enumerate gaps 
 
 Cases that test finding detection include a `defects:` block listing expected defects. Each defect has `{item, dim, sev, desc}`. Cases testing behavior (not detection) have `defects: N/A`. Clean-artifact cases have `defects: []`. Used by `/run-eval-cases` for FP/FN precision/recall measurement.
 
-The behavior kinds split by what they assert: `behavior_analytics` (analytics diff-tracking), `behavior_scaffold` (scaffold filesystem writes), `behavior_apply_policy` (deterministic apply-risk policy lookup — verified in pytest, not by the LLM runner), and **`behavior_review`** (review-orchestrator *process* behavior — e.g. dimension-traversal completeness or meta-condition detection, as opposed to which findings the reviewer emits). `behavior_review` is the form the D-series review-behavior cases (#128/#129/#130/#132/#136) use; see Case 24 for the reference exemplar.
+The behavior kinds split by what they assert: `behavior_analytics` (analytics diff-tracking), `behavior_scaffold` (scaffold filesystem writes), `behavior_apply_policy` (deterministic apply-risk policy lookup — verified in pytest, not by the LLM runner), and **`behavior_review`** (review-orchestrator *process* behavior — e.g. dimension-traversal completeness or meta-condition detection, as opposed to which findings the reviewer emits). `behavior_review` is the form the D-series review-behavior cases (#128/#129/#130/#132/#136) use; see Case 24 for the reference exemplar and Case 25 for stub-primitive handling.
 
 The C1–C5 narrative sections were removed when those cases moved to YAML. The C6–C18 sections below preserve the narrative format pending a follow-up migration.
 
@@ -419,3 +419,51 @@ Sprint contract:
 - **C20-3 (regression signal):** reviewer emits a partial grade block missing one or
   more applicable dimensions, OR scores a dimension structurally inapplicable to a
   skill artifact
+
+## Case 25 — D6 stub-primitive handling (behavior_review)
+
+(YAML: `tests/eval_cases/case_21_stub_behavior_review.yaml`)
+
+Fixture: `tests/fixtures/eval/case_21_stub.SKILL.md` — a well-formed SKILL.md with
+valid YAML frontmatter (`name:` + `description:`) followed by exactly one non-blank
+body line. No workflow, steps, error-handling, or sections — the absence of substantive
+body content is the point. Staged read-only via `cp`; `/review-skill` does not mutate
+its target.
+
+defects: N/A (asserts reviewer behavior against a stub primitive, not detection of a
+seeded defect in a complete artifact)
+
+D6 label. This case guards against reviewer hallucination: confidently grading a
+near-empty primitive on content-dependent dimensions where there is no substantive
+body to assess. Unlike `detection`/`clean` cases, it asserts a property of review
+*process* behavior. The pytest layer (`tests/test_eval_cases.py`) validates only the
+YAML structure; the behavioral assertion (C21-1/C21-2) is LLM-driven and runs only
+via `/run-eval-cases`, which is non-deterministic — there is no programmatic replay
+path for it.
+
+Sprint contract:
+- **C21-1 (correct behavior):** EITHER the certificate raises an explicit stub /
+  insufficient-content finding, OR **no** content-dependent dimension (Completeness,
+  Prompt Engineering, Context Engineering, Goal Alignment) is awarded a confident high
+  grade (A or B).
+- **C21-2 (regression signal):** no stub/insufficiency finding is raised AND at least
+  one content-dependent dimension is awarded a confident high grade (A or B) — the
+  reviewer confidently grades a no-content dimension as if the stub were a complete
+  primitive (hallucination). C21-1 and C21-2 are exact complements: every review output
+  lands in exactly one, with no quantifier dead zone.
+
+Regression signal: reviewer returns A or B on any of Completeness, Prompt Engineering,
+Context Engineering, or Goal Alignment for a primitive with no substantive body content,
+without raising a stub / insufficient-content finding.
+
+Reconciliation note: issue #132 specified "reviewer returns NOT letter grades / all
+dimensions null/N/A" but `/review-skill` mandates exactly 7 dimension rows plus Overall
+(`skills/review-skill/SKILL.md:118-119`). The sprint contract is reconciled to the SUT
+contract — correct behavior is the mandated 7-row block where content-dependent
+dimensions grade low and/or an explicit stub/insufficient finding is raised. User
+decision: close #132 on the four structural ACs; post-merge layer-(b) verification
+(`/run-eval-cases 21`) confirms the behavioral guard fires.
+
+Note: the doc `## Case N` heading sequence is decoupled from the YAML `case_NN`
+filename sequence (this Case 25 maps to `case_21`); the YAML pointer line above is the
+disambiguator.

--- a/tests/eval_cases/case_21_stub_behavior_review.yaml
+++ b/tests/eval_cases/case_21_stub_behavior_review.yaml
@@ -1,0 +1,65 @@
+id: case-21-stub-behavior-review
+kind: behavior_review
+description: >-
+  D6 stub-primitive handling — asserts /review-skill reflects insufficiency on a
+  near-empty primitive rather than hallucinating confident high grades on
+  content-dependent dimensions with no substantive content to assess.
+target_skill: review-skill
+artifacts:
+  primary: tests/fixtures/eval/case_21_stub.SKILL.md
+defects: N/A
+sprint_contract:
+  - id: C21-1
+    description: >-
+      Correct behavior: EITHER the certificate raises an explicit stub /
+      insufficient-content finding, OR no content-dependent dimension
+      (Completeness, Prompt Engineering, Context Engineering, Goal Alignment)
+      is awarded a confident high grade (A or B). The presence of a confident
+      A/B on any content-dependent dimension — with no substantive body to
+      assess — is the hallucination signal this case guards against.
+  - id: C21-2
+    description: >-
+      Regression signal — exact complement of C21-1: no stub/insufficiency
+      finding is raised AND at least one content-dependent dimension
+      (Completeness, Prompt Engineering, Context Engineering, Goal Alignment)
+      is awarded a confident high grade (A or B). This means the reviewer
+      confidently graded a no-content dimension as if the stub were a complete
+      primitive (hallucination). Every review output lands in exactly one of
+      C21-1 / C21-2 — there is no quantifier dead zone.
+acceptance: null
+execution:
+  dispatch:
+    command: /review-skill
+    target_arg: tests/fixtures/eval/case_21_stub.SKILL.md
+    orchestration:
+      websearch_available: false
+      webfetch_available: false
+  timeout_seconds: 60
+fix_target:
+  reviewer_behavior: skills/review-skill/SKILL.md
+notes: |
+  D6 stub-primitive eval case. Reconciliation with #132 literal phrasing: issue
+  #132 specified "reviewer returns NOT letter grades / all dimensions null/N/A"
+  but /review-skill mandates exactly 7 dimension rows plus Overall
+  (skills/review-skill/SKILL.md:118-119). The sprint contract is reconciled to the
+  SUT contract — correct behavior is the mandated 7-row block where
+  content-dependent dimensions grade low and/or an explicit stub/insufficient
+  finding is raised; regression is confident high grades on dimensions with no
+  content to assess. User decision: close #132 on the four structural ACs.
+
+  kind: behavior_review — no findings_fixture; the behavioral assertion (C21-1/
+  C21-2) is LLM-driven and runs only via /run-eval-cases, which is
+  non-deterministic. There is no programmatic replay path for it in
+  tests/test_eval_cases.py (only the universal YAML-structure check runs).
+
+  defects: N/A (asserts reviewer behavior against a stub primitive, not
+  detection of a seeded defect in a complete artifact).
+
+  Reuses the detection/clean staging flow: the staged temp path is reviewed, not
+  the live fixture. /review-skill does not mutate its target. Template: see
+  Case 24 / case_20_behavior_review_reference.yaml.
+
+  Post-merge behavioral verification: run /run-eval-cases 21 in a fresh
+  plugin-loaded session (claude --plugin-dir .) to confirm /review-skill
+  satisfies C21-1 and does NOT exhibit C21-2. This is a layer-(b) follow-up,
+  not an issue-AC blocker.

--- a/tests/eval_cases/case_21_stub_behavior_review.yaml
+++ b/tests/eval_cases/case_21_stub_behavior_review.yaml
@@ -9,7 +9,7 @@ artifacts:
   primary: tests/fixtures/eval/case_21_stub.SKILL.md
 defects: N/A
 sprint_contract:
-  - id: C21-1
+  - id: C25-1
     description: >-
       Correct behavior: EITHER the certificate raises an explicit stub /
       insufficient-content finding, OR no content-dependent dimension
@@ -17,15 +17,15 @@ sprint_contract:
       is awarded a confident high grade (A or B). The presence of a confident
       A/B on any content-dependent dimension — with no substantive body to
       assess — is the hallucination signal this case guards against.
-  - id: C21-2
+  - id: C25-2
     description: >-
-      Regression signal — exact complement of C21-1: no stub/insufficiency
+      Regression signal — exact complement of C25-1: no stub/insufficiency
       finding is raised AND at least one content-dependent dimension
       (Completeness, Prompt Engineering, Context Engineering, Goal Alignment)
       is awarded a confident high grade (A or B). This means the reviewer
       confidently graded a no-content dimension as if the stub were a complete
       primitive (hallucination). Every review output lands in exactly one of
-      C21-1 / C21-2 — there is no quantifier dead zone.
+      C25-1 / C25-2 — there is no quantifier dead zone.
 acceptance: null
 execution:
   dispatch:
@@ -47,8 +47,8 @@ notes: |
   finding is raised; regression is confident high grades on dimensions with no
   content to assess. User decision: close #132 on the four structural ACs.
 
-  kind: behavior_review — no findings_fixture; the behavioral assertion (C21-1/
-  C21-2) is LLM-driven and runs only via /run-eval-cases, which is
+  kind: behavior_review — no findings_fixture; the behavioral assertion (C25-1/
+  C25-2) is LLM-driven and runs only via /run-eval-cases, which is
   non-deterministic. There is no programmatic replay path for it in
   tests/test_eval_cases.py (only the universal YAML-structure check runs).
 
@@ -61,5 +61,5 @@ notes: |
 
   Post-merge behavioral verification: run /run-eval-cases 21 in a fresh
   plugin-loaded session (claude --plugin-dir .) to confirm /review-skill
-  satisfies C21-1 and does NOT exhibit C21-2. This is a layer-(b) follow-up,
+  satisfies C25-1 and does NOT exhibit C25-2. This is a layer-(b) follow-up,
   not an issue-AC blocker.

--- a/tests/fixtures/eval/case_21_stub.SKILL.md
+++ b/tests/fixtures/eval/case_21_stub.SKILL.md
@@ -1,0 +1,6 @@
+---
+name: eval-test-stub
+description: Stub skill for D6 hallucination regression — used by case_21_stub_behavior_review to verify /review-skill reflects insufficiency on a near-empty primitive.
+---
+
+This skill is intentionally minimal — no workflow, no steps, no error-handling sections.


### PR DESCRIPTION
## Summary

Adds the D6 empty/stub-primitive eval case (issue #132), a `behavior_review`
regression case mirroring the case_20 template. It guards against `/review-skill`
hallucinating confident high grades on a near-empty primitive.

- `tests/fixtures/eval/case_21_stub.SKILL.md` — minimal stub fixture (valid
  frontmatter + one body line).
- `tests/eval_cases/case_21_stub_behavior_review.yaml` — `kind: behavior_review`,
  sprint contract C21-1/C21-2 (C21-2 the exact complement of C21-1).
- `docs/review-eval-cases.md` — Case 25 section + behavior-kinds pointer.

## Reconciliation note

Issue #132's literal sprint-contract ("reviewer returns NOT letter grades / all
dimensions null/N/A") conflicts with `/review-skill`'s hard output contract
(mandatory 7-dimension grade block). Per user decision, the case is reconciled to
the SUT contract: correct behavior = an explicit stub/insufficient finding OR no
content-dependent dimension graded at confident A/B; regression = the complement.

## Verification

- AC1 fixture shape, AC2 doc section (`^## Case [0-9]+ .*[Ss]tub` + sub-parts),
  AC3 `make validate` (1120 passed, 2 skipped), AC4 `pytest -k case_21_stub`
  discovery + structural pass — all green.
- Behavioral assertion (C21-1/C21-2) is LLM-driven (`behavior_review` has no
  programmatic replay by design); first proof-of-fire is the post-merge layer-(b)
  `/run-eval-cases 21` run, accepted as a documented follow-up.

Closes: #132